### PR TITLE
Add dynamic activation policy for window focus recovery

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3EB8C4AB75DF90CAAA7764C0 /* AppIcon_original.svg in Resources */ = {isa = PBXBuildFile; fileRef = D8736AEED259ECCE858F5BFE /* AppIcon_original.svg */; };
 		40504C9B5C87311686050C85 /* RandomNameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200952D514CDC6E761D7D31 /* RandomNameGenerator.swift */; };
 		41DAD45FEC5310D0E461CE31 /* Worktree.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE7A83D915B984C5F6EEEAC /* Worktree.swift */; };
+		638E6CA1194A56DF7C449566 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C843B3047D22F1A56EAE0AFB /* WindowObserver.swift */; };
 		653587B67AD671EEE36C6C93 /* OhMyWorktreeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCCF64227A4F11AF7BA80B6 /* OhMyWorktreeError.swift */; };
 		69D877CD7133DCC2B86870EC /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C48E8BD55146561E170E91A /* WorktreeRowView.swift */; };
 		83813D0890D4D7B8E1705EE3 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7C98BC9064213F12D218E3 /* SettingsView.swift */; };
@@ -60,6 +61,7 @@
 		C2067200F123B0207E5A6D16 /* ActionButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButtonsView.swift; sourceTree = "<group>"; };
 		C219D40D70456373AB9C842E /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		C49FD4751640C27A346AD443 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C843B3047D22F1A56EAE0AFB /* WindowObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowObserver.swift; sourceTree = "<group>"; };
 		CFCCF64227A4F11AF7BA80B6 /* OhMyWorktreeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyWorktreeError.swift; sourceTree = "<group>"; };
 		CFE13C2BA3698FDC9C68D625 /* EnvFileCopier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvFileCopier.swift; sourceTree = "<group>"; };
 		D8736AEED259ECCE858F5BFE /* AppIcon_original.svg */ = {isa = PBXFileReference; path = AppIcon_original.svg; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 				A200952D514CDC6E761D7D31 /* RandomNameGenerator.swift */,
 				5DE83D40D208FBAE22E78A33 /* RepositoryStore.swift */,
 				FFB32A5891B624A9E58CAA49 /* UpdaterManager.swift */,
+				C843B3047D22F1A56EAE0AFB /* WindowObserver.swift */,
 				6A761722B5707AF84AB6CA37 /* WorktreeManager.swift */,
 			);
 			path = Services;
@@ -262,6 +265,7 @@
 				BA7B508992779E01ED6514B9 /* RepositoryStore.swift in Sources */,
 				83813D0890D4D7B8E1705EE3 /* SettingsView.swift in Sources */,
 				ADBE2761848EDD4D7448F958 /* UpdaterManager.swift in Sources */,
+				638E6CA1194A56DF7C449566 /* WindowObserver.swift in Sources */,
 				41DAD45FEC5310D0E461CE31 /* Worktree.swift in Sources */,
 				9CA230CEB954B49CE4036FB9 /* WorktreeListView.swift in Sources */,
 				C81634CFFA3B0D0B1D6DC1E4 /* WorktreeListViewModel.swift in Sources */,

--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -21,12 +21,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var menuRefreshTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
     private let headMonitor = GitHeadMonitor()
+    private let windowObserver = WindowObserver()
     private var liveBranchName: String?
 
     // MARK: - NSApplicationDelegate
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
         setupStatusItem()
+        windowObserver.startObserving()
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            showOrCreateMainWindow()
+        }
+        return true
     }
 
     // MARK: - Observe ViewModel Changes
@@ -459,19 +469,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // MARK: - Actions: Open Main Window
 
     @objc private func openMainWindowClicked(_ sender: NSMenuItem) {
-        NSApp.activate(ignoringOtherApps: true)
-
-        // Try to show an existing window first
-        for window in NSApp.windows where window.canBecomeMain {
-            window.makeKeyAndOrderFront(nil)
-            if window.isMiniaturized {
-                window.deminiaturize(nil)
-            }
-            return
-        }
-
-        // No existing window - create a new one via SwiftUI
-        openMainWindow?()
+        showOrCreateMainWindow()
     }
 
     // MARK: - Actions: Settings

--- a/OhMyWorktree/OhMyWorktreeApp.swift
+++ b/OhMyWorktree/OhMyWorktreeApp.swift
@@ -13,7 +13,6 @@ struct OhMyWorktreeApp: App {
                 .frame(minWidth: 400, minHeight: 300)
                 .modifier(OpenWindowModifier(appDelegate: appDelegate))
                 .onAppear {
-                    NSApp.setActivationPolicy(.accessory)
                     appDelegate.repoViewModel = repoViewModel
                     appDelegate.worktreeViewModel = worktreeViewModel
                     appDelegate.updaterManager = updaterManager

--- a/OhMyWorktree/Services/WindowObserver.swift
+++ b/OhMyWorktree/Services/WindowObserver.swift
@@ -1,0 +1,122 @@
+import AppKit
+
+/// Observes window lifecycle events and dynamically toggles the app's activation policy
+/// between `.accessory` (menu-bar-only) and `.regular` (Dock + Cmd+Tab).
+///
+/// When at least one app window is visible or miniaturized, the app switches to `.regular`
+/// so that Cmd+` and Cmd+Tab work. When all windows are closed, it switches back to `.accessory`
+/// so the Dock icon disappears.
+@MainActor
+final class WindowObserver {
+
+    private var isObserving = false
+
+    func startObserving() {
+        guard !isObserving else { return }
+        isObserving = true
+
+        let center = NotificationCenter.default
+
+        center.addObserver(
+            self,
+            selector: #selector(windowDidBecomeKey(_:)),
+            name: NSWindow.didBecomeKeyNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(windowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(windowDidMiniaturize(_:)),
+            name: NSWindow.didMiniaturizeNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(windowDidDeminiaturize(_:)),
+            name: NSWindow.didDeminiaturizeNotification,
+            object: nil
+        )
+    }
+
+    // MARK: - Notification Handlers
+
+    @objc private func windowDidBecomeKey(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, isAppWindow(window) else { return }
+        updateActivationPolicy()
+    }
+
+    @objc private func windowWillClose(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, isAppWindow(window) else { return }
+        // Defer the check so the window has time to actually close
+        DispatchQueue.main.async { [weak self] in
+            self?.updateActivationPolicy()
+        }
+    }
+
+    @objc private func windowDidMiniaturize(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, isAppWindow(window) else { return }
+        updateActivationPolicy()
+    }
+
+    @objc private func windowDidDeminiaturize(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, isAppWindow(window) else { return }
+        updateActivationPolicy()
+    }
+
+    // MARK: - Policy Management
+
+    private func updateActivationPolicy() {
+        let hasAppWindows = NSApp.windows.contains { window in
+            isAppWindow(window) && (window.isVisible || window.isMiniaturized)
+        }
+
+        let desiredPolicy: NSApplication.ActivationPolicy = hasAppWindows ? .regular : .accessory
+        let currentPolicy = NSApp.activationPolicy()
+
+        guard desiredPolicy != currentPolicy else { return }
+
+        NSApp.setActivationPolicy(desiredPolicy)
+
+        if desiredPolicy == .regular {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    // MARK: - Window Filtering
+
+    /// Returns true for real app windows (main window, settings), false for
+    /// transient system windows (status bar, popovers, tooltips, etc.).
+    private func isAppWindow(_ window: NSWindow) -> Bool {
+        let className = String(describing: type(of: window))
+
+        // Filter out known system/transient window types
+        let transientTypes = [
+            "NSStatusBarWindow",
+            "_NSPopoverWindow",
+            "NSToolTipPanel",
+            "NSMenuWindowManagerWindow",
+            "_NSAlertPanel",
+        ]
+        if transientTypes.contains(className) {
+            return false
+        }
+
+        // Must have a title bar or be a standard window level
+        if window.level != .normal {
+            return false
+        }
+
+        // Must have standard window style (title bar or closable)
+        let hasStandardChrome = window.styleMask.contains(.titled)
+        return hasStandardChrome
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -473,6 +473,46 @@ branch refs/heads/feature/new-feature
 
 ---
 
+#### FR-026: 동적 Activation Policy — 윈도우 포커스 복구 (P1)
+
+**설명**: 윈도우 가시성에 따라 `NSApplication.ActivationPolicy`를 동적으로 전환하여 Cmd+\` 및 Cmd+Tab을 통한 윈도우 포커스 복구 지원
+
+**배경**:
+- `.accessory` 모드에서는 Dock 아이콘과 Cmd+Tab이 비활성화되어, 메인 윈도우가 포커스를 잃으면 메뉴바 아이콘 클릭 외에 복구 수단 없음
+- 1Password, Bartender 등 주요 macOS 유틸리티에서 사용하는 표준 패턴 적용
+
+**상세 요구사항**:
+- `WindowObserver` 서비스: 윈도우 라이프사이클 이벤트 감시
+  - `NSWindow.didBecomeKeyNotification` — 윈도우 활성화
+  - `NSWindow.willCloseNotification` — 윈도우 닫힘
+  - `NSWindow.didMiniaturizeNotification` — 윈도우 최소화
+  - `NSWindow.didDeminiaturizeNotification` — 최소화 해제
+- Activation Policy 전환 로직:
+  - 앱 윈도우가 1개 이상 visible 또는 miniaturized → `.regular` (Dock + Cmd+Tab 활성)
+  - 모든 앱 윈도우 닫힘 → `.accessory` (Dock 아이콘 숨김, 메뉴바 전용)
+- `.regular` 전환 시 `NSApp.activate()` 호출하여 즉시 Dock/Cmd+Tab 등록
+- 트랜지언트 윈도우 필터링:
+  - `NSStatusBarWindow`, `_NSPopoverWindow`, `NSToolTipPanel` 등 시스템 윈도우 제외
+  - `window.level == .normal` 및 `.titled` 스타일 마스크 확인
+- Dock 아이콘 클릭 시 (`applicationShouldHandleReopen`) 윈도우가 없으면 메인 윈도우 생성
+- 초기 정책: `applicationDidFinishLaunching`에서 `.accessory`로 설정 (기존 `.onAppear` 설정 제거)
+
+**영향받는 컴포넌트**:
+- `WindowObserver` (신규 서비스)
+- `AppDelegate`: WindowObserver 통합, `applicationShouldHandleReopen` 추가, `openMainWindowClicked` 중복 코드 제거
+- `OhMyWorktreeApp`: `.onAppear`에서 `setActivationPolicy(.accessory)` 제거
+
+**검증 시나리오**:
+1. 앱 실행 → 메인 윈도우 표시, Dock 아이콘 나타남, Cmd+Tab에 앱 표시
+2. 다른 앱 클릭 → Dock 아이콘 유지, Cmd+\`로 윈도우 복귀 가능
+3. 메인 윈도우 닫기 → Dock 아이콘 사라짐, 메뉴바 전용 모드
+4. 메뉴바에서 윈도우 열기 → Dock 아이콘 재등장
+5. Settings 열기 → Dock 아이콘 표시; Settings만 닫고 메인 윈도우 유지 → Dock 아이콘 유지
+6. 모든 윈도우 닫기 → Dock 아이콘 사라짐
+7. Dock 아이콘 클릭 (윈도우 없는 상태) → 메인 윈도우 생성
+
+---
+
 #### FR-022: 메뉴바 타이틀 실시간 브랜치 감지 (P1)
 
 **설명**: 선택된 worktree의 git HEAD 파일을 모니터링하여 외부 브랜치 변경 시 메뉴바 타이틀을 실시간 갱신
@@ -1110,6 +1150,7 @@ graph TB
         C[Repository Manager]
         D[Worktree Manager]
         E[External Tool Launcher]
+        K[Window Observer]
     end
 
     subgraph "Data Layer"
@@ -1141,6 +1182,7 @@ graph TB
     style C fill:#fff9c4
     style D fill:#fff9c4
     style E fill:#fff9c4
+    style K fill:#fff9c4
     style F fill:#c8e6c9
     style G fill:#c8e6c9
     style H fill:#ffccbc
@@ -1785,6 +1827,7 @@ end tell
 | 1.1.5 | 2026-02-07 | .env 파일 재귀 탐색 (FR-018 개선) — 모노레포 하위 디렉토리 .env 파일 지원, node_modules/dist 등 제외 디렉토리 설정 | Claude Code |
 | 1.1.6 | 2026-02-10 | 원본 worktree Git Pull 기능 (FR-024), 원본 worktree 삭제 보호 (FR-025) 추가; 원본 vs 생성된 worktree 컨텍스트 메뉴 분리 | Claude Code |
 | 1.1.7 | 2026-02-14 | 코드 리뷰 반영 — `isMainWorktree` 저장 프로퍼티를 `isRoot(of:)` 메서드로 변경 (경로 정규화 및 안전한 비교), Git Pull 동시 실행 방지 (`pullingWorktrees` 세트), 메뉴바 Git Pull 실행 시 메인 윈도우 표시로 일관된 피드백, 메뉴바 Repository 선택 시 메인 윈도우 표시, `GitCommandExecutor` Sendable 추가 (Swift 6 대응) | Claude Code |
+| 1.1.9 | 2026-02-26 | 동적 Activation Policy (FR-026) — WindowObserver 서비스 추가, 윈도우 가시성에 따른 .accessory/.regular 전환으로 Cmd+\` 및 Cmd+Tab 포커스 복구 지원, Dock 아이콘 클릭 시 윈도우 생성, openMainWindowClicked 중복 코드 제거 | Claude Code |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `WindowObserver` service that dynamically toggles activation policy between `.accessory` (menu-bar-only) and `.regular` (Dock + Cmd+Tab) based on window visibility
- When windows are open, Dock icon appears and **Cmd+`** / **Cmd+Tab** work for focus recovery
- When all windows are closed, Dock icon disappears and the app returns to pure menu-bar mode
- Add `applicationShouldHandleReopen` so clicking the Dock icon with no windows opens the main window
- Refactor `openMainWindowClicked` to reuse `showOrCreateMainWindow()` (removes duplicate code)
- Update PRD with FR-026

## Test plan

- [ ] Launch app → main window visible, Dock icon appears, app in Cmd+Tab
- [ ] Click away → Dock icon stays, **Cmd+` brings window back**
- [ ] Close main window → Dock icon disappears, pure menu-bar mode
- [ ] Open window from menu bar → Dock icon reappears
- [ ] Open Settings → Dock icon appears; close Settings with main window open → stays
- [ ] Close all windows → Dock icon disappears
- [ ] Click Dock icon when no windows → main window opens

🤖 Generated with [Claude Code](https://claude.ai/code)