### PR TITLE
Add cmux terminal support

### DIFF
--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -285,6 +285,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             submenu.addItem(item)
         }
 
+        if worktreeViewModel?.isCmuxAvailable == true {
+            let item = NSMenuItem(
+                title: "Open in cmux",
+                action: #selector(openInCmuxClicked(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = ref
+            submenu.addItem(item)
+        }
+
         if submenu.numberOfItems > 0 {
             submenu.addItem(.separator())
         }
@@ -411,6 +422,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             guard let self else { return }
             let worktree = self.worktreeViewModel?.worktrees.first(where: { $0.id == ref.id })
             await self.worktreeViewModel?.openInCursor(worktree)
+        }
+    }
+
+    @objc private func openInCmuxClicked(_ sender: NSMenuItem) {
+        guard let ref = sender.representedObject as? WorktreeRef else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let worktree = self.worktreeViewModel?.worktrees.first(where: { $0.id == ref.id })
+            await self.worktreeViewModel?.openInCmux(worktree)
         }
     }
 

--- a/OhMyWorktree/Services/ExternalToolLauncher.swift
+++ b/OhMyWorktree/Services/ExternalToolLauncher.swift
@@ -72,6 +72,39 @@ final class ExternalToolLauncher {
         process.waitUntilExit()
     }
 
+    // MARK: - cmux
+
+    func openInCmux(path: String) async throws {
+        guard isCmuxInstalled() else {
+            throw OhMyWorktreeError.externalToolNotFound(tool: "cmux")
+        }
+
+        let socketPath = "/tmp/cmux.sock"
+
+        // If cmux is not running, launch it and wait for the socket
+        if !FileManager.default.fileExists(atPath: socketPath) {
+            let launchProcess = Process()
+            launchProcess.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            launchProcess.arguments = ["-a", "cmux"]
+            try launchProcess.run()
+            launchProcess.waitUntilExit()
+
+            for _ in 0..<50 {
+                if FileManager.default.fileExists(atPath: socketPath) { break }
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+            guard FileManager.default.fileExists(atPath: socketPath) else { return }
+        }
+
+        try cmuxSocketCommand(socketPath: socketPath) { send in
+            let result = try send("new_workspace")
+            let workspaceID = result.replacingOccurrences(of: "OK ", with: "")
+            _ = try send("select_workspace \(workspaceID)")
+            _ = try send("send cd \(path)")
+            _ = try send("send_key enter")
+        }
+    }
+
     // MARK: - Tool Detection
 
     func isITermInstalled() -> Bool {
@@ -90,6 +123,10 @@ final class ExternalToolLauncher {
         FileManager.default.fileExists(atPath: "/Applications/Cursor.app")
     }
 
+    func isCmuxInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: "/Applications/cmux.app")
+    }
+
     // MARK: - Private Helpers
 
     private func findVSCodeCLI() throws -> String {
@@ -106,6 +143,59 @@ final class ExternalToolLauncher {
         }
 
         throw OhMyWorktreeError.externalToolNotFound(tool: "Visual Studio Code")
+    }
+
+    private func cmuxSocketCommand(socketPath: String, commands: (_ send: (String) throws -> String) throws -> Void) throws {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw OhMyWorktreeError.commandExecutionFailed(command: "cmux", stderr: "Failed to create socket")
+        }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        socketPath.withCString { src in
+            withUnsafeMutableBytes(of: &addr.sun_path) { rawBuf in
+                let dest = rawBuf.baseAddress!.assumingMemoryBound(to: CChar.self)
+                _ = strcpy(dest, src)
+            }
+        }
+
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else {
+            throw OhMyWorktreeError.commandExecutionFailed(command: "cmux", stderr: "Failed to connect to cmux socket")
+        }
+
+        let sendCommand: (String) throws -> String = { command in
+            let message = command + "\n"
+            _ = message.withCString { ptr in
+                Darwin.send(fd, ptr, strlen(ptr), 0)
+            }
+
+            usleep(100_000)
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            let bytesRead = recv(fd, &buffer, buffer.count, 0)
+            guard bytesRead > 0 else {
+                throw OhMyWorktreeError.commandExecutionFailed(command: "cmux \(command)", stderr: "No response")
+            }
+            let response = String(bytes: buffer[..<bytesRead], encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !response.hasPrefix("ERROR") else {
+                if response.contains("Access denied") {
+                    throw OhMyWorktreeError.commandExecutionFailed(
+                        command: "cmux",
+                        stderr: "cmux socket access denied. Open cmux Settings → Automation → Socket Control Mode → set to \"Full open access\", then restart cmux."
+                    )
+                }
+                throw OhMyWorktreeError.commandExecutionFailed(command: "cmux \(command)", stderr: response)
+            }
+            return response
+        }
+
+        try commands(sendCommand)
     }
 
 }

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -268,6 +268,18 @@ final class WorktreeListViewModel: ObservableObject {
         }
     }
 
+    func openInCmux(_ worktree: Worktree? = nil) async {
+        let target = worktree ?? selectedWorktree
+        guard let target else { return }
+
+        do {
+            try await toolLauncher.openInCmux(path: target.path)
+            await recordActivity(for: target)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     func recordActivity(for worktree: Worktree) async {
         guard let repository else { return }
         await store.updateLastActivity(folderName: worktree.folderName, repositoryID: repository.id)
@@ -293,6 +305,10 @@ final class WorktreeListViewModel: ObservableObject {
 
     var isCursorAvailable: Bool {
         toolLauncher.isCursorInstalled()
+    }
+
+    var isCmuxAvailable: Bool {
+        toolLauncher.isCmuxInstalled()
     }
 
     // MARK: - Error Handling

--- a/OhMyWorktree/Views/ActionButtonsView.swift
+++ b/OhMyWorktree/Views/ActionButtonsView.swift
@@ -41,6 +41,14 @@ struct ActionButtonsView: View {
                 Task { await viewModel.openInCursor() }
             }
 
+            actionButton(
+                title: "cmux",
+                icon: "rectangle.topthird.inset.filled",
+                isAvailable: viewModel.isCmuxAvailable
+            ) {
+                Task { await viewModel.openInCmux() }
+            }
+
             Spacer()
 
             if hasSelection {

--- a/OhMyWorktree/Views/WorktreeListView.swift
+++ b/OhMyWorktree/Views/WorktreeListView.swift
@@ -106,6 +106,11 @@ struct WorktreeListView: View {
         }
         .disabled(!viewModel.isCursorAvailable)
 
+        Button("Open in cmux") {
+            Task { await viewModel.openInCmux(worktree) }
+        }
+        .disabled(!viewModel.isCmuxAvailable)
+
         if let repository = viewModel.repository, worktree.isRoot(of: repository) {
             Divider()
 


### PR DESCRIPTION
## Summary

- Add cmux as a supported external terminal tool alongside iTerm, Ghostty, VSCode, and Cursor
- Communicate with cmux via Unix socket (text-based protocol) to create new workspaces and navigate to worktree paths
- Show a guided error message when socket access is denied, directing users to enable "Full open access" in cmux Settings → Automation → Socket Control Mode

## Changes

- **ExternalToolLauncher.swift**: `openInCmux()` with Unix socket communication (`new_workspace` → `select_workspace` → `send cd` → `send_key enter`), falls back to `open -a cmux` if cmux is not running
- **WorktreeListViewModel.swift**: `openInCmux()` method and `isCmuxAvailable` property
- **ActionButtonsView.swift**: cmux button in the main window toolbar
- **WorktreeListView.swift**: "Open in cmux" in the right-click context menu
- **AppDelegate.swift**: "Open in cmux" in the menu bar worktree submenu

## Note

cmux requires **Socket Control Mode → Full open access** in cmux Settings for external app integration. The app shows a specific error message guiding users to this setting.

## Test plan

- [ ] Verify cmux button appears in main window toolbar when cmux is installed
- [ ] Verify "Open in cmux" appears in right-click context menu and menu bar submenu
- [ ] Click "Open in cmux" → new workspace opens at the worktree path
- [ ] Test with cmux not running → app launches cmux, waits for socket, then opens workspace
- [ ] Test with socket access denied → user-friendly error message is shown
- [ ] Verify cmux button is disabled when cmux is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)