### PR TITLE
Add worktree rename with inline editing (FR-030)

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14E42FFD99B49D00630EA203 /* WorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD25714038218BA848A16DA /* WorktreeTests.swift */; };
+		150BA7D5A0121054A1307FF1 /* WorktreeMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E37907BD97EF1278CAD9A1B /* WorktreeMetadataTests.swift */; };
 		156C6EB8ECDE30DC56C50A6B /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1B43B188C597C61F1DC2EA /* Repository.swift */; };
 		1D280B90168CDB181DC5FAE4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73CCA7E1C1ACBAF4E4291EA8 /* Assets.xcassets */; };
 		1D5329DDE42009E76C2650C5 /* ExternalToolLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B3645306233DD226910E8 /* ExternalToolLauncher.swift */; };
@@ -28,6 +30,7 @@
 		937BABFBB6A058168B1F67D3 /* MenuBarIcon.svg in Resources */ = {isa = PBXBuildFile; fileRef = BDCFA92CC6D4F4BDC422F3E2 /* MenuBarIcon.svg */; };
 		96B92319C7A41781AC764E80 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219D40D70456373AB9C842E /* AppSettings.swift */; };
 		9CA230CEB954B49CE4036FB9 /* WorktreeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AE572EAF819FF7917FB985 /* WorktreeListView.swift */; };
+		A00DF8B5591361457887300F /* RepositoryStoreRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A81FF314A143B73B1AB7C8 /* RepositoryStoreRenameTests.swift */; };
 		A04EF872B11EC64861D1931F /* PullRequestInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F3D7DAE61099FF17488E05 /* PullRequestInfoTests.swift */; };
 		A1B84A7C2495A084A1A9A9C3 /* GitHeadMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0B554A7A3F05F099599D36 /* GitHeadMonitor.swift */; };
 		A7622C78F2ECEA8730DB9443 /* WorktreeMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F0F523CFE13B485CFE49BC /* WorktreeMetadata.swift */; };
@@ -59,8 +62,10 @@
 		051710DB8E7D2B5BEF352CDF /* OhMyWorktreeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OhMyWorktreeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0590D938B57D29A509B839A9 /* RepositorySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySettingsView.swift; sourceTree = "<group>"; };
 		1024573DB028DE97085DF606 /* PullRequestStateIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequestStateIcon.swift; sourceTree = "<group>"; };
+		13A81FF314A143B73B1AB7C8 /* RepositoryStoreRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryStoreRenameTests.swift; sourceTree = "<group>"; };
 		155B3645306233DD226910E8 /* ExternalToolLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalToolLauncher.swift; sourceTree = "<group>"; };
 		1E244AEB611F8ACEFC7862B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1E37907BD97EF1278CAD9A1B /* WorktreeMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeMetadataTests.swift; sourceTree = "<group>"; };
 		284A4CA5F96802A6098EA38B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		31E4C67AC16118B79418121C /* OhMyWorktreeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OhMyWorktreeApp.swift; sourceTree = "<group>"; };
 		38E89BED48AC12D1BE0AA667 /* WorktreeListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListViewModel.swift; sourceTree = "<group>"; };
@@ -73,6 +78,7 @@
 		73CCA7E1C1ACBAF4E4291EA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8C48E8BD55146561E170E91A /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		8D0B554A7A3F05F099599D36 /* GitHeadMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHeadMonitor.swift; sourceTree = "<group>"; };
+		9BD25714038218BA848A16DA /* WorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeTests.swift; sourceTree = "<group>"; };
 		A200952D514CDC6E761D7D31 /* RandomNameGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomNameGenerator.swift; sourceTree = "<group>"; };
 		A34554C16FE6EC54FBB5C200 /* RepositoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListViewModel.swift; sourceTree = "<group>"; };
 		AB7DCB0D9BD7764BC9BC08F6 /* OhMyWorktree.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OhMyWorktree.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,7 +143,10 @@
 			children = (
 				C9F3D7DAE61099FF17488E05 /* PullRequestInfoTests.swift */,
 				038E188FA5528808D1BCFCC7 /* PullRequestServiceTests.swift */,
+				13A81FF314A143B73B1AB7C8 /* RepositoryStoreRenameTests.swift */,
 				45E90BF743990ABDF5F54752 /* WorktreeFileCopierTests.swift */,
+				1E37907BD97EF1278CAD9A1B /* WorktreeMetadataTests.swift */,
+				9BD25714038218BA848A16DA /* WorktreeTests.swift */,
 			);
 			path = OhMyWorktreeTests;
 			sourceTree = "<group>";
@@ -306,7 +315,10 @@
 			files = (
 				A04EF872B11EC64861D1931F /* PullRequestInfoTests.swift in Sources */,
 				38723E3C67DD58A9D57EAD4B /* PullRequestServiceTests.swift in Sources */,
+				A00DF8B5591361457887300F /* RepositoryStoreRenameTests.swift in Sources */,
 				671DEF7953036D7C339F1C16 /* WorktreeFileCopierTests.swift in Sources */,
+				150BA7D5A0121054A1307FF1 /* WorktreeMetadataTests.swift in Sources */,
+				14E42FFD99B49D00630EA203 /* WorktreeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -104,7 +104,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         if let repo = repoViewModel?.selectedRepository {
             if let worktree = worktreeViewModel?.selectedWorktree {
-                let branchDisplay = liveBranchName ?? worktree.displayName
+                let branchDisplay = worktree.customName ?? liveBranchName ?? worktree.displayName
                 button.title = " \(repo.name)/\(branchDisplay)"
             } else {
                 button.title = " \(repo.name)"

--- a/OhMyWorktree/Models/Worktree.swift
+++ b/OhMyWorktree/Models/Worktree.swift
@@ -10,9 +10,13 @@ struct Worktree: Identifiable, Hashable {
     let isBare: Bool
     let isLocked: Bool
     var lastActivityAt: Date?
+    var customName: String?
 
     var displayName: String {
-        branch ?? "Detached (\(commitHash.prefix(7)))"
+        if let customName, !customName.isEmpty {
+            return customName
+        }
+        return branch ?? "Detached (\(commitHash.prefix(7)))"
     }
 
     /// Check if this worktree is the root/main worktree of the given repository.
@@ -94,7 +98,8 @@ struct Worktree: Identifiable, Hashable {
         lhs.commitHash == rhs.commitHash &&
         lhs.isDetached == rhs.isDetached &&
         lhs.isBare == rhs.isBare &&
-        lhs.isLocked == rhs.isLocked
+        lhs.isLocked == rhs.isLocked &&
+        lhs.customName == rhs.customName
     }
 
     func hash(into hasher: inout Hasher) {
@@ -105,5 +110,6 @@ struct Worktree: Identifiable, Hashable {
         hasher.combine(isDetached)
         hasher.combine(isBare)
         hasher.combine(isLocked)
+        hasher.combine(customName)
     }
 }

--- a/OhMyWorktree/Models/WorktreeMetadata.swift
+++ b/OhMyWorktree/Models/WorktreeMetadata.swift
@@ -4,10 +4,12 @@ struct WorktreeMetadata: Codable, Hashable {
     let folderName: String
     let createdAt: Date
     var lastActivityAt: Date
+    var customName: String?
 
-    init(folderName: String, createdAt: Date = Date(), lastActivityAt: Date? = nil) {
+    init(folderName: String, createdAt: Date = Date(), lastActivityAt: Date? = nil, customName: String? = nil) {
         self.folderName = folderName
         self.createdAt = createdAt
         self.lastActivityAt = lastActivityAt ?? createdAt
+        self.customName = customName
     }
 }

--- a/OhMyWorktree/Services/RepositoryStore.swift
+++ b/OhMyWorktree/Services/RepositoryStore.swift
@@ -162,6 +162,18 @@ actor RepositoryStore {
         saveToDisk()
     }
 
+    func updateCustomName(folderName: String, customName: String?, repositoryID: UUID) {
+        guard let index = worktreeMetadata[repositoryID]?.firstIndex(where: { $0.folderName == folderName }) else {
+            return
+        }
+        let sanitized = customName.flatMap { name in
+            let trimmed = name.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        worktreeMetadata[repositoryID]?[index].customName = sanitized
+        saveToDisk()
+    }
+
     // MARK: - Env Copy Overrides
 
     func getEnvCopyOverride(for repositoryID: UUID) -> Bool? {

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -72,11 +72,13 @@ final class WorktreeListViewModel: ObservableObject {
                 guard !Task.isCancelled else { return }
                 let metadata = await self.store.getWorktreeMetadata(repositoryID: repository.id)
 
-                // Enrich worktrees with last activity time
+                // Enrich worktrees with metadata (customName, last activity time)
                 for i in freshWorktrees.indices {
                     guard !Task.isCancelled else { return }
                     let wt = freshWorktrees[i]
-                    let metaActivity = metadata.first(where: { $0.folderName == wt.folderName })?.lastActivityAt
+                    let meta = metadata.first(where: { $0.folderName == wt.folderName })
+                    freshWorktrees[i].customName = meta?.customName
+                    let metaActivity = meta?.lastActivityAt
                     let commitDate = await self.worktreeManager.lastCommitDate(worktreePath: wt.path)
 
                     // Use the most recent of metadata activity and last commit
@@ -248,6 +250,29 @@ final class WorktreeListViewModel: ObservableObject {
         else { return }
 
         NSWorkspace.shared.open(pr.url)
+    }
+
+    // MARK: - Rename Worktree
+
+    func renameWorktree(_ worktree: Worktree, newName: String) async {
+        guard let repository else { return }
+
+        let trimmed = newName.trimmingCharacters(in: .whitespaces)
+        let customName: String? = trimmed.isEmpty ? nil : trimmed
+
+        await store.updateCustomName(
+            folderName: worktree.folderName,
+            customName: customName,
+            repositoryID: repository.id
+        )
+
+        // Update local state immediately
+        if let index = worktrees.firstIndex(where: { $0.id == worktree.id }) {
+            worktrees[index].customName = customName
+        }
+        if selectedWorktree?.id == worktree.id {
+            selectedWorktree?.customName = customName
+        }
     }
 
     // MARK: - Open in External Tools

--- a/OhMyWorktree/Views/WorktreeListView.swift
+++ b/OhMyWorktree/Views/WorktreeListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct WorktreeListView: View {
     @ObservedObject var viewModel: WorktreeListViewModel
+    @State private var renamingWorktreeID: UUID?
 
     var body: some View {
         Group {
@@ -33,7 +34,17 @@ struct WorktreeListView: View {
                         WorktreeRowView(
                             worktree: worktree,
                             pullRequest: worktree.branch.flatMap { viewModel.pullRequests[$0] },
-                            onOpenPullRequest: { viewModel.openPullRequest(for: worktree) }
+                            isRenaming: renamingWorktreeID == worktree.id,
+                            onOpenPullRequest: { viewModel.openPullRequest(for: worktree) },
+                            onRename: { newName in
+                                renamingWorktreeID = nil
+                                Task {
+                                    await viewModel.renameWorktree(worktree, newName: newName)
+                                }
+                            },
+                            onCancelRename: {
+                                renamingWorktreeID = nil
+                            }
                         )
                             .tag(worktree.id)
                             .contextMenu {
@@ -42,6 +53,13 @@ struct WorktreeListView: View {
                     }
                 }
                 .listStyle(.inset(alternatesRowBackgrounds: true))
+                .onKeyPress(.return) {
+                    if renamingWorktreeID == nil, let selected = viewModel.selectedWorktree {
+                        renamingWorktreeID = selected.id
+                        return .handled
+                    }
+                    return .ignored
+                }
             }
         }
         .overlay(alignment: .bottomTrailing) {
@@ -90,6 +108,12 @@ struct WorktreeListView: View {
 
     @ViewBuilder
     private func contextMenuItems(for worktree: Worktree) -> some View {
+        Button("Rename") {
+            renamingWorktreeID = worktree.id
+        }
+
+        Divider()
+
         Button("Open in iTerm") {
             Task { await viewModel.openInITerm(worktree) }
         }

--- a/OhMyWorktree/Views/WorktreeRowView.swift
+++ b/OhMyWorktree/Views/WorktreeRowView.swift
@@ -3,7 +3,13 @@ import SwiftUI
 struct WorktreeRowView: View {
     let worktree: Worktree
     var pullRequest: PullRequestInfo?
+    var isRenaming: Bool = false
     var onOpenPullRequest: (() -> Void)?
+    var onRename: ((String) -> Void)?
+    var onCancelRename: (() -> Void)?
+
+    @State private var editingName: String = ""
+    @FocusState private var isTextFieldFocused: Bool
 
     var body: some View {
         HStack(spacing: 10) {
@@ -11,9 +17,26 @@ struct WorktreeRowView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(worktree.displayName)
+                    if isRenaming {
+                        TextField("", text: $editingName)
                         .font(.system(.body, design: .default, weight: .medium))
-                        .lineLimit(1)
+                        .textFieldStyle(.plain)
+                        .focused($isTextFieldFocused)
+                        .onSubmit {
+                            onRename?(editingName)
+                        }
+                        .onExitCommand {
+                            onCancelRename?()
+                        }
+                        .onAppear {
+                            editingName = worktree.customName ?? worktree.displayName
+                            isTextFieldFocused = true
+                        }
+                    } else {
+                        Text(worktree.displayName)
+                            .font(.system(.body, design: .default, weight: .medium))
+                            .lineLimit(1)
+                    }
 
                     if let pr = pullRequest {
                         prBadge(pr)

--- a/OhMyWorktreeTests/RepositoryStoreRenameTests.swift
+++ b/OhMyWorktreeTests/RepositoryStoreRenameTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import OhMyWorktree
+
+final class RepositoryStoreRenameTests: XCTestCase {
+
+    // Each test gets a unique repository ID to prevent cross-test interference
+    private var testRepoID: UUID!
+    private let store = RepositoryStore.shared
+    private let testFolderName = "test-worktree-rename-\(UUID().uuidString.prefix(8))"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testRepoID = UUID()
+        // Ensure clean state before each test
+        await store.removeWorktreeMetadata(folderName: testFolderName, repositoryID: testRepoID)
+    }
+
+    override func tearDown() async throws {
+        // Clean up test data after each test
+        await store.removeWorktreeMetadata(folderName: testFolderName, repositoryID: testRepoID)
+        try await super.tearDown()
+    }
+
+    // MARK: - updateCustomName
+
+    func testUpdateCustomName_setsCustomName() async {
+        // Given: metadata exists without customName
+        let metadata = WorktreeMetadata(folderName: testFolderName)
+        await store.addWorktreeMetadata(metadata, repositoryID: testRepoID)
+
+        // When: update customName
+        await store.updateCustomName(folderName: testFolderName, customName: "My Feature", repositoryID: testRepoID)
+
+        // Then: customName is persisted
+        let result = await store.getWorktreeMetadata(repositoryID: testRepoID)
+        let found = result.first(where: { $0.folderName == self.testFolderName })
+        XCTAssertEqual(found?.customName, "My Feature")
+    }
+
+    func testUpdateCustomName_clearsCustomName_withNil() async {
+        // Given: metadata has a customName
+        let metadata = WorktreeMetadata(folderName: testFolderName, customName: "My Feature")
+        await store.addWorktreeMetadata(metadata, repositoryID: testRepoID)
+
+        // When: set customName to nil
+        await store.updateCustomName(folderName: testFolderName, customName: nil, repositoryID: testRepoID)
+
+        // Then: customName is cleared
+        let result = await store.getWorktreeMetadata(repositoryID: testRepoID)
+        let found = result.first(where: { $0.folderName == self.testFolderName })
+        XCTAssertNil(found?.customName)
+    }
+
+    func testUpdateCustomName_sanitizesWhitespaceOnlyToNil() async {
+        // Given: metadata exists
+        let metadata = WorktreeMetadata(folderName: testFolderName)
+        await store.addWorktreeMetadata(metadata, repositoryID: testRepoID)
+
+        // When: set customName to whitespace-only
+        await store.updateCustomName(folderName: testFolderName, customName: "   ", repositoryID: testRepoID)
+
+        // Then: customName is sanitized to nil
+        let result = await store.getWorktreeMetadata(repositoryID: testRepoID)
+        let found = result.first(where: { $0.folderName == self.testFolderName })
+        XCTAssertNil(found?.customName)
+    }
+
+    func testUpdateCustomName_trimsWhitespace() async {
+        // Given: metadata exists
+        let metadata = WorktreeMetadata(folderName: testFolderName)
+        await store.addWorktreeMetadata(metadata, repositoryID: testRepoID)
+
+        // When: set customName with leading/trailing whitespace
+        await store.updateCustomName(folderName: testFolderName, customName: "  My Feature  ", repositoryID: testRepoID)
+
+        // Then: customName is trimmed
+        let result = await store.getWorktreeMetadata(repositoryID: testRepoID)
+        let found = result.first(where: { $0.folderName == self.testFolderName })
+        XCTAssertEqual(found?.customName, "My Feature")
+    }
+
+    func testUpdateCustomName_nonExistentFolder_doesNothing() async {
+        // When: update customName for non-existent folder
+        await store.updateCustomName(folderName: "nonexistent-\(testRepoID!.uuidString)", customName: "Name", repositoryID: testRepoID)
+
+        // Then: no metadata created
+        let result = await store.getWorktreeMetadata(repositoryID: testRepoID)
+        XCTAssertTrue(result.isEmpty)
+    }
+}

--- a/OhMyWorktreeTests/WorktreeMetadataTests.swift
+++ b/OhMyWorktreeTests/WorktreeMetadataTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import OhMyWorktree
+
+final class WorktreeMetadataTests: XCTestCase {
+
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    // MARK: - customName encode/decode
+
+    func testEncodeDecode_withCustomName() throws {
+        let metadata = WorktreeMetadata(folderName: "bright-ocean", customName: "My Feature")
+
+        let data = try encoder.encode(metadata)
+        let decoded = try decoder.decode(WorktreeMetadata.self, from: data)
+
+        XCTAssertEqual(decoded.folderName, "bright-ocean")
+        XCTAssertEqual(decoded.customName, "My Feature")
+    }
+
+    func testEncodeDecode_withNilCustomName() throws {
+        let metadata = WorktreeMetadata(folderName: "bright-ocean")
+
+        let data = try encoder.encode(metadata)
+        let decoded = try decoder.decode(WorktreeMetadata.self, from: data)
+
+        XCTAssertEqual(decoded.folderName, "bright-ocean")
+        XCTAssertNil(decoded.customName)
+    }
+
+    func testDecode_backwardCompatibility_withoutCustomNameField() throws {
+        // Simulate JSON from older version that doesn't have customName field
+        let json = """
+        {
+            "folderName": "bright-ocean",
+            "createdAt": "2026-02-27T00:00:00Z",
+            "lastActivityAt": "2026-02-27T00:00:00Z"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try decoder.decode(WorktreeMetadata.self, from: data)
+
+        XCTAssertEqual(decoded.folderName, "bright-ocean")
+        XCTAssertNil(decoded.customName)
+    }
+}

--- a/OhMyWorktreeTests/WorktreeTests.swift
+++ b/OhMyWorktreeTests/WorktreeTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+@testable import OhMyWorktree
+
+final class WorktreeTests: XCTestCase {
+
+    // MARK: - displayName with customName
+
+    func testDisplayName_returnsCustomName_whenSet() {
+        var worktree = Worktree(
+            path: "/repo/worktrees/bright-ocean",
+            folderName: "bright-ocean",
+            branch: "feature/login",
+            commitHash: "abc1234"
+        )
+        worktree.customName = "My Feature"
+
+        XCTAssertEqual(worktree.displayName, "My Feature")
+    }
+
+    // MARK: - displayName fallback
+
+    func testDisplayName_returnsBranch_whenCustomNameIsNil() {
+        let worktree = Worktree(
+            path: "/repo/worktrees/bright-ocean",
+            folderName: "bright-ocean",
+            branch: "feature/login",
+            commitHash: "abc1234"
+        )
+
+        XCTAssertNil(worktree.customName)
+        XCTAssertEqual(worktree.displayName, "feature/login")
+    }
+
+    func testDisplayName_returnsBranch_whenCustomNameIsEmpty() {
+        var worktree = Worktree(
+            path: "/repo/worktrees/bright-ocean",
+            folderName: "bright-ocean",
+            branch: "feature/login",
+            commitHash: "abc1234"
+        )
+        worktree.customName = ""
+
+        XCTAssertEqual(worktree.displayName, "feature/login")
+    }
+
+    func testDisplayName_returnsCustomName_whenWhitespaceOnly() {
+        // Note: In practice, RepositoryStore sanitizes whitespace-only to nil.
+        // The model trusts its input and returns customName as-is.
+        var worktree = Worktree(
+            path: "/repo/worktrees/bright-ocean",
+            folderName: "bright-ocean",
+            branch: "feature/login",
+            commitHash: "abc1234"
+        )
+        worktree.customName = "   "
+
+        XCTAssertEqual(worktree.displayName, "   ")
+    }
+
+    func testDisplayName_returnsDetached_whenNoBranchAndNoCustomName() {
+        let worktree = Worktree(
+            path: "/repo/worktrees/bright-ocean",
+            folderName: "bright-ocean",
+            commitHash: "abc1234567890"
+        )
+
+        XCTAssertEqual(worktree.displayName, "Detached (abc1234)")
+    }
+}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -597,6 +597,37 @@ branch refs/heads/feature/new-feature
 
 ---
 
+#### FR-030: Worktree 이름 변경 (Rename) (P1)
+
+**설명**: Worktree에 사용자 지정 이름(customName)을 설정하여 표시 이름을 변경할 수 있음. 이름을 비우면 기존 표기 룰(브랜치명 또는 Detached)로 복귀.
+
+**상세 요구사항**:
+- `WorktreeMetadata`에 `customName: String?` 필드 추가
+- `Worktree`에 `customName: String?` 필드 추가, ViewModel에서 metadata로부터 주입
+- `displayName` 로직 변경: `customName(비어있지 않으면) → branch → "Detached (commit)"`
+- 이름 변경 트리거:
+  - 메인 윈도우 리스트에서 우클릭 → "Rename" 컨텍스트 메뉴 항목
+  - 워크트리 선택 후 Enter 키 입력 (Finder 파일 이름 변경과 동일 UX)
+- 인라인 편집:
+  - 워크트리 행의 displayName 텍스트가 TextField로 전환
+  - Enter 입력 시 저장, Escape 입력 시 취소
+  - 빈 문자열 제출 시 customName 제거 (기존 표기 룰 복귀)
+- `RepositoryStore`에 `updateCustomName(folderName:customName:repositoryID:)` 메서드 추가
+- `WorktreeListViewModel`에 `renameWorktree(_:newName:)` 메서드 추가
+- 메뉴 바 드롭다운 및 상태 바 타이틀에도 customName 자동 반영 (displayName 로직 변경으로 커버)
+- JSON 하위호환: customName 필드 없는 기존 데이터 로드 시 nil로 처리
+
+**영향받는 컴포넌트**:
+- `WorktreeMetadata` (customName 필드 추가)
+- `Worktree` (customName 필드, displayName 로직 변경)
+- `RepositoryStore` (updateCustomName 메서드)
+- `WorktreeListViewModel` (renameWorktree, loadWorktrees enrichment)
+- `WorktreeListView` (컨텍스트 메뉴 Rename 항목, Enter 키 바인딩)
+- `WorktreeRowView` (인라인 TextField 전환)
+- `AppDelegate` (displayName 변경으로 자동 반영)
+
+---
+
 #### FR-022: 메뉴바 타이틀 실시간 브랜치 감지 (P1)
 
 **설명**: 선택된 worktree의 git HEAD 파일을 모니터링하여 외부 브랜치 변경 시 메뉴바 타이틀을 실시간 갱신
@@ -847,6 +878,7 @@ Force Remove Worktree
   - **Worktree 메타데이터** (각 repository별):
     - 폴더명 (folderName) - 안정적인 식별자
     - 생성 날짜
+    - 사용자 지정 이름 (customName, optional) — FR-030
 - **중요**: 브랜치명은 저장하지 않음 (항상 `git worktree list --porcelain`로 실시간 조회)
 
 **데이터 구조**:
@@ -1485,9 +1517,13 @@ struct Worktree: Identifiable {
     let isDetached: Bool
     let isBare: Bool
     let isLocked: Bool
+    var customName: String?  // 사용자 지정 이름 (FR-030, WorktreeMetadata에서 주입)
 
     var displayName: String {
-        branch ?? "Detached (\(commitHash.prefix(7)))"
+        if let customName, !customName.isEmpty {
+            return customName
+        }
+        return branch ?? "Detached (\(commitHash.prefix(7)))"
     }
 }
 ```
@@ -1501,10 +1537,12 @@ struct Worktree: Identifiable {
 - `isDetached`: detached HEAD 상태 여부
 - `isBare`: bare worktree 여부
 - `isLocked`: locked 상태 여부
+- `customName`: 사용자 지정 표시 이름 (nil이면 기존 룰; RepositoryStore에서 저장 시 trim/nil 변환 보장) — FR-030
 
 **중요**:
 - `branch`는 메타데이터에 저장되지 않음 (사용자가 CLI에서 브랜치 변경 가능)
 - `folderName`은 불변이며 worktree의 안정적인 식별자로 사용됨
+- `customName`은 `WorktreeMetadata`에 저장되며, ViewModel에서 로드 시 주입됨
 
 ---
 
@@ -1752,7 +1790,7 @@ gantt
 
 | 기능 | 우선순위 | 예상 일정 |
 |------|----------|-----------|
-| Worktree 이름 변경 | P2 | v1.1 |
+| ~~Worktree 이름 변경~~ | ~~P2~~ | ✅ FR-030으로 구현 완료 |
 | 브랜치 전환 (in worktree) | P2 | v1.1 |
 | 커밋 히스토리 간단 표시 | P2 | v1.2 |
 | 다른 터미널 앱 지원 (Alacritty 등) | P2 | v1.2 |
@@ -1917,6 +1955,7 @@ end tell
 | 1.2.0 | 2026-02-26 | .worktreeinclude 패턴 기반 파일 복사 (FR-027) — EnvFileCopier를 WorktreeFileCopier로 대체, `.worktreeinclude` glob 패턴 지원, fnmatch 기반 매칭, `.worktreeinclude` 미존재 시 `.env*` 폴백으로 하위호환 유지, UI 레이블 업데이트 | Claude Code |
 | 1.2.1 | 2026-02-26 | GitHub PR 번호 표시 (FR-028) — `gh` CLI 기반 PR 정보 조회, 브랜치별 PR 번호 배지, 클릭 시 PR 페이지 열기, PullRequestFetching 프로토콜, race condition 방지 | Claude Code |
 | 1.2.2 | 2026-02-27 | GitHub PR 상태 아이콘 (FR-029) — open/merged/closed 상태 표시, GitHub 옥티콘 SVG 아이콘 (Asset Catalog), 상태별 색상 배지, `--state all`로 전체 PR 조회, open 우선순위 로직 | Claude Code |
+| 1.3.0 | 2026-02-27 | Worktree 이름 변경 (FR-030) — WorktreeMetadata에 customName 필드 추가, displayName 우선순위 로직 (customName → branch → detached), 인라인 TextField 편집 (Finder 스타일), 컨텍스트 메뉴 Rename 항목, Enter 키 트리거, 빈 문자열로 기본 표기 복귀, JSON 하위호환 | Claude Code |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add custom display name (`customName`) support for worktrees, persisted in `WorktreeMetadata`
- Inline TextField editing triggered by context menu "Rename" or Enter key (Finder-style UX)
- Display priority: `customName → liveBranchName → branch → "Detached (commit)"`
- Store-level input sanitization (trim whitespace, empty-to-nil) keeps data clean
- Backward-compatible JSON: existing data without `customName` loads as nil

## Test plan
- [x] Build succeeds
- [x] All tests pass (3 new test files: WorktreeTests, WorktreeMetadataTests, RepositoryStoreRenameTests)
- [ ] Right-click worktree → "Rename" → inline TextField appears
- [ ] Select worktree + Enter key → inline TextField appears
- [ ] Type new name + Enter → name saved and displayed
- [ ] Escape during rename → cancels without saving
- [ ] Submit empty name → reverts to branch name display
- [ ] Menu bar title reflects custom name
- [ ] Restart app → custom names persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)