### PR TITLE
Fix empty menu bar on cold start after reboot

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		3EB8C4AB75DF90CAAA7764C0 /* AppIcon_original.svg in Resources */ = {isa = PBXBuildFile; fileRef = D8736AEED259ECCE858F5BFE /* AppIcon_original.svg */; };
 		40504C9B5C87311686050C85 /* RandomNameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200952D514CDC6E761D7D31 /* RandomNameGenerator.swift */; };
 		41DAD45FEC5310D0E461CE31 /* Worktree.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE7A83D915B984C5F6EEEAC /* Worktree.swift */; };
+		454889617A7D8475686FA15A /* AppDelegateColdStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C7BE2DF5F955131E669BE3 /* AppDelegateColdStartTests.swift */; };
 		59C9E6B4357FF5942927E09E /* ImportPRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A03AD181020CC2A2003500 /* ImportPRView.swift */; };
 		5FF69FC201062F843B4C9297 /* WorktreeListViewModel+ExternalTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E110EB7715E49CA580231B2 /* WorktreeListViewModel+ExternalTools.swift */; };
 		638E6CA1194A56DF7C449566 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C843B3047D22F1A56EAE0AFB /* WindowObserver.swift */; };
@@ -94,6 +95,7 @@
 		3E110EB7715E49CA580231B2 /* WorktreeListViewModel+ExternalTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorktreeListViewModel+ExternalTools.swift"; sourceTree = "<group>"; };
 		41217BF38EB2E221F3B98D28 /* ImportPRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPRViewModel.swift; sourceTree = "<group>"; };
 		45E90BF743990ABDF5F54752 /* WorktreeFileCopierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeFileCopierTests.swift; sourceTree = "<group>"; };
+		48C7BE2DF5F955131E669BE3 /* AppDelegateColdStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateColdStartTests.swift; sourceTree = "<group>"; };
 		55F7FDE98A327CB12943BBD9 /* AppDelegate+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Actions.swift"; sourceTree = "<group>"; };
 		5DE83D40D208FBAE22E78A33 /* RepositoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryStore.swift; sourceTree = "<group>"; };
 		6460930465C1945BB9E708A7 /* WorktreeListViewModelSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListViewModelSelectionTests.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 		3B56166A537E658017960706 /* OhMyWorktreeTests */ = {
 			isa = PBXGroup;
 			children = (
+				48C7BE2DF5F955131E669BE3 /* AppDelegateColdStartTests.swift */,
 				CA1521E4788D6CDF1C92F4C9 /* BackgroundJobStateTests.swift */,
 				04943FBE79E108AEA932BE7A /* BackgroundTaskQueueTests.swift */,
 				8D4E99B69FBE28C8558EEC50 /* ImportPRViewModelTests.swift */,
@@ -395,6 +398,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				454889617A7D8475686FA15A /* AppDelegateColdStartTests.swift in Sources */,
 				0DCEB362F2A309D8F5E5360D /* BackgroundJobStateTests.swift in Sources */,
 				018CEB4BA33463D66FC56390 /* BackgroundTaskQueueTests.swift in Sources */,
 				BF12B0124F855ED64994FC08 /* ImportPRViewModelTests.swift in Sources */,

--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -8,7 +8,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // MARK: - Properties
 
     var statusItem: NSStatusItem?
-    var repoViewModel: RepositoryListViewModel?
+    var repoViewModel: RepositoryListViewModel? {
+        didSet {
+            guard repoViewModel !== oldValue else { return }
+            observeRepositoryChanges()
+        }
+    }
     var worktreeViewModel: WorktreeListViewModel? {
         didSet {
             guard worktreeViewModel !== oldValue else { return }
@@ -21,6 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var updaterManager: UpdaterManager?
     private var menuRefreshTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
+    private var repoCancellables = Set<AnyCancellable>()
     private let headMonitor = GitHeadMonitor()
     private let windowObserver = WindowObserver()
     private var liveBranchName: String?
@@ -41,6 +47,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     // MARK: - Observe ViewModel Changes
+
+    private func observeRepositoryChanges() {
+        repoCancellables.removeAll()
+
+        guard let repoViewModel else { return }
+
+        // Eagerly load repositories so the menu bar is populated
+        // even before the main window appears (fixes cold-start on reboot).
+        if repoViewModel.repositories.isEmpty {
+            Task {
+                await repoViewModel.loadRepositories()
+            }
+        }
+
+        // Rebuild menu whenever the repository list or selection changes.
+        repoViewModel.$repositories
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.rebuildMenu()
+                self?.updateStatusItemTitle()
+            }
+            .store(in: &repoCancellables)
+
+        repoViewModel.$selectedRepository
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.rebuildMenu()
+                self?.updateStatusItemTitle()
+            }
+            .store(in: &repoCancellables)
+    }
 
     private func observeWorktreeChanges() {
         cancellables.removeAll()
@@ -122,6 +159,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menuRefreshTask?.cancel()
         menuRefreshTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            // Ensure repositories are loaded (cold-start safety net)
+            if self.repoViewModel?.repositories.isEmpty == true {
+                await self.repoViewModel?.loadRepositories()
+            }
             let before = self.worktreeViewModel?.worktrees
             await self.worktreeViewModel?.loadWorktrees(debounce: true)
             // Only rebuild if data actually changed to avoid menu flicker

--- a/OhMyWorktree/OhMyWorktreeApp.swift
+++ b/OhMyWorktree/OhMyWorktreeApp.swift
@@ -8,6 +8,12 @@ struct OhMyWorktreeApp: App {
     @StateObject private var updaterManager = UpdaterManager()
 
     var body: some Scene {
+        // Connect view models to AppDelegate during Scene body evaluation,
+        // so the menu bar works even if the main window hasn't appeared yet
+        // (e.g. cold start after reboot with Login Items).
+        // swiftlint:disable:next redundant_discardable_let
+        let _ = connectAppDelegate()
+
         WindowGroup(id: "main") {
             ContentView(repoViewModel: repoViewModel, worktreeViewModel: worktreeViewModel)
                 .frame(minWidth: 400, minHeight: 300)
@@ -15,11 +21,6 @@ struct OhMyWorktreeApp: App {
                     ImportPRView(worktreeViewModel: worktreeViewModel)
                 }
                 .modifier(OpenWindowModifier(appDelegate: appDelegate, worktreeViewModel: worktreeViewModel))
-                .onAppear {
-                    appDelegate.repoViewModel = repoViewModel
-                    appDelegate.worktreeViewModel = worktreeViewModel
-                    appDelegate.updaterManager = updaterManager
-                }
         }
         .defaultSize(width: 500, height: 400)
         .windowResizability(.contentSize)
@@ -27,6 +28,12 @@ struct OhMyWorktreeApp: App {
         Settings {
             SettingsView(updaterManager: updaterManager)
         }
+    }
+
+    private func connectAppDelegate() {
+        appDelegate.repoViewModel = repoViewModel
+        appDelegate.worktreeViewModel = worktreeViewModel
+        appDelegate.updaterManager = updaterManager
     }
 }
 

--- a/OhMyWorktreeTests/AppDelegateColdStartTests.swift
+++ b/OhMyWorktreeTests/AppDelegateColdStartTests.swift
@@ -1,0 +1,91 @@
+import Combine
+import XCTest
+
+@testable import OhMyWorktree
+
+/// Tests for the cold-start race condition fix where the menu bar would show
+/// an empty repository list when the app launched via Login Items on reboot.
+///
+/// Root cause: `repoViewModel` was only connected to AppDelegate in
+/// ContentView's `.onAppear`, and `loadRepositories()` was only called in
+/// ContentView's `.task`. If the main window hadn't appeared yet, the menu
+/// bar had no data.
+///
+/// Fix: `repoViewModel.didSet` now eagerly loads repositories and subscribes
+/// to changes via Combine, ensuring the menu is populated regardless of
+/// window state.
+@MainActor
+final class AppDelegateColdStartTests: XCTestCase {
+
+    private var testRepo: Repository!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testRepo = Repository(
+            name: "cold-start-test",
+            path: "/tmp/cold-start-\(UUID().uuidString)"
+        )
+        await RepositoryStore.shared.addRepository(testRepo)
+    }
+
+    override func tearDown() async throws {
+        await RepositoryStore.shared.removeRepository(id: testRepo.id)
+        try await super.tearDown()
+    }
+
+    // MARK: - repoViewModel.didSet triggers eager load
+
+    func testRepoViewModelDidSetTriggersEagerLoad() async throws {
+        // Given: A fresh ViewModel whose repositories have NOT been loaded
+        let vm = RepositoryListViewModel()
+        XCTAssertTrue(vm.repositories.isEmpty)
+
+        // When: The ViewModel is assigned to AppDelegate
+        // (simulates the moment SwiftUI connects it, before any window appears)
+        let appDelegate = AppDelegate()
+        appDelegate.setupStatusItem()
+
+        let loaded = expectation(description: "Repositories loaded after didSet")
+        let cancellable = vm.$repositories
+            .dropFirst()
+            .first(where: { $0.contains(where: { $0.id == self.testRepo.id }) })
+            .sink { _ in loaded.fulfill() }
+
+        appDelegate.repoViewModel = vm
+
+        // Then: didSet → observeRepositoryChanges → loadRepositories
+        await fulfillment(of: [loaded], timeout: 3.0)
+        XCTAssertTrue(vm.repositories.contains(where: { $0.id == testRepo.id }))
+        cancellable.cancel()
+    }
+
+    // MARK: - Menu is populated after cold-start load
+
+    func testMenuPopulatedAfterColdStartLoad() async throws {
+        let vm = RepositoryListViewModel()
+        let appDelegate = AppDelegate()
+        appDelegate.setupStatusItem()
+
+        let loaded = expectation(description: "Repositories loaded")
+        let cancellable = vm.$repositories
+            .dropFirst()
+            .first(where: { $0.contains(where: { $0.id == self.testRepo.id }) })
+            .sink { _ in loaded.fulfill() }
+
+        appDelegate.repoViewModel = vm
+        await fulfillment(of: [loaded], timeout: 3.0)
+        cancellable.cancel()
+
+        // Combine subscription in observeRepositoryChanges calls rebuildMenu;
+        // give the run loop one tick to process it.
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Then: The menu should contain the test repository
+        guard let menu = appDelegate.statusItem?.menu else {
+            XCTFail("Status item menu should exist")
+            return
+        }
+        let repoItem = menu.items.first(where: { $0.title == testRepo.name })
+        XCTAssertNotNil(repoItem, "Menu should contain the repository after cold-start loading")
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug**: When the app launched via Login Items on reboot, the menu bar showed no repositories (empty menu). Quitting and relaunching fixed it.
- **Root cause**: `repoViewModel` was connected to AppDelegate only in ContentView's `.onAppear`, and `loadRepositories()` was only called in ContentView's `.task`. On cold start, the main window hadn't appeared yet, so the menu bar had no data.
- **Fix**: Move ViewModel connection to Scene body evaluation (window-independent), add `didSet` observer on `repoViewModel` for eager loading and Combine subscription, add `menuWillOpen` safety net.

## Changes

- `OhMyWorktreeApp.swift`: Replace `.onAppear` with `connectAppDelegate()` called during Scene body evaluation
- `AppDelegate.swift`: Add `repoViewModel.didSet` → `observeRepositoryChanges()` (matches existing `worktreeViewModel` pattern), add repo load fallback in `menuWillOpen`
- `AppDelegateColdStartTests.swift`: Regression tests verifying eager load on ViewModel assignment and menu population

## Test plan

- [x] `testRepoViewModelDidSetTriggersEagerLoad` — verifies `didSet` triggers `loadRepositories()`
- [x] `testMenuPopulatedAfterColdStartLoad` — verifies menu contains repo items after cold-start load
- [x] All existing tests pass
- [x] SwiftLint clean (0 violations)
- [ ] Manual: Set as Login Item → reboot → verify menu shows repositories immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)