### PR TITLE
Parallelize lastCommitDate calls with TaskGroup

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		653587B67AD671EEE36C6C93 /* OhMyWorktreeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCCF64227A4F11AF7BA80B6 /* OhMyWorktreeError.swift */; };
 		671DEF7953036D7C339F1C16 /* WorktreeFileCopierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E90BF743990ABDF5F54752 /* WorktreeFileCopierTests.swift */; };
 		69D877CD7133DCC2B86870EC /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C48E8BD55146561E170E91A /* WorktreeRowView.swift */; };
+		6E910BF7F1044EC6205BEBE8 /* WorktreeListViewModelEnrichedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1C9F86B57A3ECFEF3DD6DE /* WorktreeListViewModelEnrichedTests.swift */; };
 		761A6C6DF0BA861B384B7BBA /* PullRequestInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0F95F0D684BC863684D8241 /* PullRequestInfo.swift */; };
 		78CA79D990B38BC4BA845726 /* MockGitExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17D255D9C03D39E65FC37E5 /* MockGitExecutor.swift */; };
 		7DC6228DB15054EE52B4F8CB /* WorktreeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A39FCA55BDC5AFC0131335 /* WorktreeManagerTests.swift */; };
@@ -105,6 +106,7 @@
 		6F7C98BC9064213F12D218E3 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		71C73C1DDF96F9DBDBE34C9D /* Date+RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+RelativeTime.swift"; sourceTree = "<group>"; };
 		73CCA7E1C1ACBAF4E4291EA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		7F1C9F86B57A3ECFEF3DD6DE /* WorktreeListViewModelEnrichedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListViewModelEnrichedTests.swift; sourceTree = "<group>"; };
 		811A9D3615B46E7D12735276 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		8C48E8BD55146561E170E91A /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		8D0B554A7A3F05F099599D36 /* GitHeadMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHeadMonitor.swift; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				038E188FA5528808D1BCFCC7 /* PullRequestServiceTests.swift */,
 				13A81FF314A143B73B1AB7C8 /* RepositoryStoreRenameTests.swift */,
 				45E90BF743990ABDF5F54752 /* WorktreeFileCopierTests.swift */,
+				7F1C9F86B57A3ECFEF3DD6DE /* WorktreeListViewModelEnrichedTests.swift */,
 				F6949AB98960591D37ABCC59 /* WorktreeListViewModelImportTests.swift */,
 				6460930465C1945BB9E708A7 /* WorktreeListViewModelSelectionTests.swift */,
 				ABF450885A0658CB279EE089 /* WorktreeListViewModelTests.swift */,
@@ -427,6 +430,7 @@
 				38723E3C67DD58A9D57EAD4B /* PullRequestServiceTests.swift in Sources */,
 				A00DF8B5591361457887300F /* RepositoryStoreRenameTests.swift in Sources */,
 				671DEF7953036D7C339F1C16 /* WorktreeFileCopierTests.swift in Sources */,
+				6E910BF7F1044EC6205BEBE8 /* WorktreeListViewModelEnrichedTests.swift in Sources */,
 				8C7C7074832657257E597751 /* WorktreeListViewModelImportTests.swift in Sources */,
 				3E3BC079BCB09601CF331D43 /* WorktreeListViewModelSelectionTests.swift in Sources */,
 				80092B38847E833C625A2FC9 /* WorktreeListViewModelTests.swift in Sources */,

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -209,6 +209,23 @@ final class WorktreeListViewModel: ObservableObject {
 
     private func enriched(_ worktrees: [Worktree], metadata: [WorktreeMetadata]) async -> [Worktree] {
         var result = worktrees
+
+        // Fetch all commit dates concurrently using TaskGroup
+        let commitDates: [Int: Date?] = await withTaskGroup(of: (Int, Date?).self) { group in
+            for i in result.indices {
+                group.addTask { [worktreeManager] in
+                    let date = await worktreeManager.lastCommitDate(worktreePath: result[i].path)
+                    return (i, date)
+                }
+            }
+            var dict = [Int: Date?]()
+            for await (index, date) in group {
+                dict[index] = date
+            }
+            return dict
+        }
+
+        // Merge with metadata (serial, fast)
         for i in result.indices {
             guard !Task.isCancelled else { return result }
             let wt = result[i]
@@ -216,7 +233,7 @@ final class WorktreeListViewModel: ObservableObject {
             result[i].customName = meta?.customName
             result[i].prRemoteBranch = meta?.prRemoteBranch
             let metaActivity = meta?.lastActivityAt
-            let commitDate = await worktreeManager.lastCommitDate(worktreePath: wt.path)
+            let commitDate = commitDates[i] ?? nil
             switch (metaActivity, commitDate) {
             case let (date1?, date2?): result[i].lastActivityAt = max(date1, date2)
             case let (date1?, nil):    result[i].lastActivityAt = date1

--- a/OhMyWorktreeTests/WorktreeListViewModelEnrichedTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelEnrichedTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+
+@testable import OhMyWorktree
+
+// MARK: - enriched() concurrent commit date tests
+// Tests for the TaskGroup-based parallel commit date fetching in WorktreeListViewModel.enriched()
+
+@MainActor
+final class WorktreeListViewModelEnrichedTests: XCTestCase {
+
+    var mockExecutor: MockWorktreeExecutor!
+    var sut: WorktreeListViewModel!
+    let testRepo = Repository(
+        name: "test-repo",
+        path: "/tmp/test-repo"
+    )
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockExecutor = MockWorktreeExecutor()
+        sut = WorktreeListViewModel(
+            worktreeManager: WorktreeManager(executor: mockExecutor),
+            store: .shared,
+            pullRequestService: MockNoPRService()
+        )
+        sut.repository = testRepo
+    }
+
+    // MARK: - Helpers
+
+    private var commitTimestamp1000: String { "1000" }
+    private var commitTimestamp2000: String { "2000" }
+    private var commitDate1000: Date { Date(timeIntervalSince1970: 1000) }
+    private var commitDate2000: Date { Date(timeIntervalSince1970: 2000) }
+    private var metadataDate1500: Date { Date(timeIntervalSince1970: 1500) }
+    private var metadataDate3000: Date { Date(timeIntervalSince1970: 3000) }
+
+    // MARK: - Tests
+
+    /// When both metadata and commit dates exist, enriched() should pick the max.
+    func testEnriched_mergesCommitAndMetadataDates_takingMax() async {
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/feature-a"] = commitTimestamp2000
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        """)
+
+        let meta = WorktreeMetadata(
+            folderName: "feature-a",
+            lastActivityAt: metadataDate1500
+        )
+        await sut.store.addWorktreeMetadata(meta, repositoryID: testRepo.id)
+
+        await sut.loadWorktrees()
+
+        let featureWt = sut.worktrees.first(where: { $0.folderName == "feature-a" })
+        XCTAssertNotNil(featureWt)
+        XCTAssertEqual(featureWt?.lastActivityAt, commitDate2000,
+                       "Should pick the later date (commit=2000 > metadata=1500)")
+    }
+
+    /// When both metadata and commit dates exist, enriched() should pick the max (metadata wins).
+    func testEnriched_mergesCommitAndMetadataDates_metadataWins() async {
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/feature-a"] = commitTimestamp1000
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        """)
+
+        let meta = WorktreeMetadata(
+            folderName: "feature-a",
+            lastActivityAt: metadataDate3000
+        )
+        await sut.store.addWorktreeMetadata(meta, repositoryID: testRepo.id)
+
+        await sut.loadWorktrees()
+
+        let featureWt = sut.worktrees.first(where: { $0.folderName == "feature-a" })
+        XCTAssertNotNil(featureWt)
+        XCTAssertEqual(featureWt?.lastActivityAt, metadataDate3000,
+                       "Should pick the later date (metadata=3000 > commit=1000)")
+    }
+
+    /// When commit date is nil (e.g. empty repo), enriched() should use metadata date alone.
+    func testEnriched_nilCommitDate_usesMetadataDate() async {
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/feature-a"] = ""
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        """)
+
+        let meta = WorktreeMetadata(
+            folderName: "feature-a",
+            lastActivityAt: metadataDate1500
+        )
+        await sut.store.addWorktreeMetadata(meta, repositoryID: testRepo.id)
+
+        await sut.loadWorktrees()
+
+        let featureWt = sut.worktrees.first(where: { $0.folderName == "feature-a" })
+        XCTAssertNotNil(featureWt)
+        XCTAssertEqual(featureWt?.lastActivityAt, metadataDate1500,
+                       "Should use metadata date when commit date is nil")
+    }
+
+    /// When metadata has no lastActivityAt (no matching metadata), enriched() should use commit date.
+    func testEnriched_nilMetadataDate_usesCommitDate() async {
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/feature-a"] = commitTimestamp2000
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        """)
+
+        // Do NOT add metadata for "feature-a" -> meta will be nil
+
+        await sut.loadWorktrees()
+
+        let featureWt = sut.worktrees.first(where: { $0.folderName == "feature-a" })
+        XCTAssertNotNil(featureWt)
+        XCTAssertEqual(featureWt?.lastActivityAt, commitDate2000,
+                       "Should use commit date when metadata is nil")
+    }
+
+    /// When the parent Task is cancelled, enriched() should return early without crashing.
+    func testEnriched_cancellation_doesNotCrash() async {
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/feature-a"] = commitTimestamp2000
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        """)
+
+        let task = Task { @MainActor in
+            await sut.loadWorktrees()
+        }
+
+        // Cancel immediately -- enriched() should handle this gracefully
+        task.cancel()
+        await task.value
+
+        // The test passes if we reach here without crashing.
+        // Worktrees may be empty (cancellation) or populated (if finished before cancel).
+        XCTAssertTrue(true, "enriched() handled cancellation without crashing")
+    }
+
+    /// Multiple worktrees should all get their commit dates (verifies concurrency correctness).
+    func testEnriched_multipleWorktrees_allGetCommitDates() async {
+        mockExecutor.commitTimestampsByPath["/tmp/test-repo"] = commitTimestamp1000
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/feature-a"] = commitTimestamp2000
+        mockExecutor.commitTimestampsByPath["/tmp/worktrees/fix-b"] = "3000"
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        worktree /tmp/worktrees/fix-b
+        HEAD abc3333
+        branch refs/heads/fix/b
+
+        """)
+
+        await sut.loadWorktrees()
+
+        XCTAssertEqual(sut.worktrees.count, 3)
+        for wt in sut.worktrees {
+            XCTAssertNotNil(wt.lastActivityAt,
+                            "Worktree '\(wt.folderName)' should have a lastActivityAt date")
+        }
+    }
+}

--- a/OhMyWorktreeTests/WorktreeListViewModelTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelTests.swift
@@ -7,12 +7,18 @@ import XCTest
 final class MockWorktreeExecutor: GitCommandExecuting, @unchecked Sendable {
     var worktreeListOutput: String = ""
     var lastCommitTimestamp: String = ""
+    /// Per-path commit timestamps. When set, overrides `lastCommitTimestamp`
+    /// for paths matching the workingDirectory of `git log` calls.
+    var commitTimestampsByPath: [String: String] = [:]
 
     func execute(command: String, arguments: [String], workingDirectory: String?) async throws -> CommandResult {
         if arguments == ["worktree", "list", "--porcelain"] {
             return CommandResult(stdout: worktreeListOutput, stderr: "", exitCode: 0)
         }
         if arguments.first == "log" {
+            if let dir = workingDirectory, let ts = commitTimestampsByPath[dir] {
+                return CommandResult(stdout: ts, stderr: "", exitCode: 0)
+            }
             return CommandResult(stdout: lastCommitTimestamp, stderr: "", exitCode: 0)
         }
         return CommandResult(stdout: "", stderr: "", exitCode: 0)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1219,6 +1219,7 @@ let nouns = ["ocean", "river", "mountain", "forest", "sky", "lunch", "pizza", ..
 - `git worktree add`: 3초 이내
 - `git worktree remove`: 2초 이내
 - 타임아웃: 30초 (사용자에게 취소 옵션 제공)
+- `git log -1 --format=%ct` (커밋 날짜 조회): worktree 목록 로드 시 `withTaskGroup`을 사용하여 모든 worktree에 대해 **병렬로** 실행. 직렬 실행 대비 N개의 worktree에서 약 N배 빠름.
 
 **NFR-003: UI 반응성 (P0)**
 - 클릭에서 반응까지: 100ms 이내


### PR DESCRIPTION
## Summary
- Replace serial `for`-loop in `WorktreeListViewModel.enriched()` with `withTaskGroup` to fetch all `lastCommitDate()` values concurrently
- Commit dates are collected into a dictionary via TaskGroup, then merged with metadata dates in a fast serial pass
- Add 6 new tests covering date merging (commit wins, metadata wins, nil commit, nil metadata, cancellation, multiple worktrees)
- Add performance note to PRD about concurrent commit date fetching

Closes #12

## Test plan
- [x] All 215 existing tests pass (0 failures)
- [x] 6 new tests in `WorktreeListViewModelEnrichedTests` verify correct date merging and cancellation handling
- [x] SwiftLint passes with 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)