### PR TITLE
Add Sentry integration for error tracking (FR-036)

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -17,9 +17,11 @@
 		156C6EB8ECDE30DC56C50A6B /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1B43B188C597C61F1DC2EA /* Repository.swift */; };
 		1D280B90168CDB181DC5FAE4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73CCA7E1C1ACBAF4E4291EA8 /* Assets.xcassets */; };
 		1D5329DDE42009E76C2650C5 /* ExternalToolLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B3645306233DD226910E8 /* ExternalToolLauncher.swift */; };
+		1F3AD538BC02934BE5D185D5 /* CrashReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A6D32025CF2B6E308B21B8 /* CrashReporterTests.swift */; };
 		322D1AFDBFEEBF607E12181D /* PullRequestStateIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1024573DB028DE97085DF606 /* PullRequestStateIcon.swift */; };
 		360142061D0A4B3D4350737F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9C6FD25E01D2C241945E1D05 /* Sparkle */; };
 		38723E3C67DD58A9D57EAD4B /* PullRequestServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038E188FA5528808D1BCFCC7 /* PullRequestServiceTests.swift */; };
+		3A8161F0ECD8D3CF35771DB9 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = F8F1840C5D81EAEA407952D8 /* Sentry */; };
 		3E3BC079BCB09601CF331D43 /* WorktreeListViewModelSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6460930465C1945BB9E708A7 /* WorktreeListViewModelSelectionTests.swift */; };
 		3EB8C4AB75DF90CAAA7764C0 /* AppIcon_original.svg in Resources */ = {isa = PBXBuildFile; fileRef = D8736AEED259ECCE858F5BFE /* AppIcon_original.svg */; };
 		40504C9B5C87311686050C85 /* RandomNameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200952D514CDC6E761D7D31 /* RandomNameGenerator.swift */; };
@@ -53,6 +55,7 @@
 		ADBE2761848EDD4D7448F958 /* UpdaterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB32A5891B624A9E58CAA49 /* UpdaterManager.swift */; };
 		B1ED113BDF88D0A3D2A2A874 /* RepositoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34554C16FE6EC54FBB5C200 /* RepositoryListViewModel.swift */; };
 		BA7B508992779E01ED6514B9 /* RepositoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE83D40D208FBAE22E78A33 /* RepositoryStore.swift */; };
+		BA8411A9040864C023E23CD8 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593B8209A3E9628B3F079464 /* CrashReporter.swift */; };
 		BE5701A4F52B99C834D7ACB5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284A4CA5F96802A6098EA38B /* ContentView.swift */; };
 		BF12B0124F855ED64994FC08 /* ImportPRViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4E99B69FBE28C8558EEC50 /* ImportPRViewModelTests.swift */; };
 		C504C333F22E91D5E0B35628 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49FD4751640C27A346AD443 /* AppDelegate.swift */; };
@@ -81,6 +84,7 @@
 		051710DB8E7D2B5BEF352CDF /* OhMyWorktreeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OhMyWorktreeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0590D938B57D29A509B839A9 /* RepositorySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySettingsView.swift; sourceTree = "<group>"; };
 		1024573DB028DE97085DF606 /* PullRequestStateIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequestStateIcon.swift; sourceTree = "<group>"; };
+		11A6D32025CF2B6E308B21B8 /* CrashReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporterTests.swift; sourceTree = "<group>"; };
 		11E235697287DAAC0D8A697C /* BackgroundJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundJob.swift; sourceTree = "<group>"; };
 		12A03AD181020CC2A2003500 /* ImportPRView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPRView.swift; sourceTree = "<group>"; };
 		13A81FF314A143B73B1AB7C8 /* RepositoryStoreRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryStoreRenameTests.swift; sourceTree = "<group>"; };
@@ -97,6 +101,7 @@
 		45E90BF743990ABDF5F54752 /* WorktreeFileCopierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeFileCopierTests.swift; sourceTree = "<group>"; };
 		48C7BE2DF5F955131E669BE3 /* AppDelegateColdStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateColdStartTests.swift; sourceTree = "<group>"; };
 		55F7FDE98A327CB12943BBD9 /* AppDelegate+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Actions.swift"; sourceTree = "<group>"; };
+		593B8209A3E9628B3F079464 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		5DE83D40D208FBAE22E78A33 /* RepositoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryStore.swift; sourceTree = "<group>"; };
 		6460930465C1945BB9E708A7 /* WorktreeListViewModelSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeListViewModelSelectionTests.swift; sourceTree = "<group>"; };
 		64B3B3B1F44A78CB74EE99F8 /* RepositorySelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySelectorView.swift; sourceTree = "<group>"; };
@@ -142,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				360142061D0A4B3D4350737F /* Sparkle in Frameworks */,
+				3A8161F0ECD8D3CF35771DB9 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +178,7 @@
 			isa = PBXGroup;
 			children = (
 				688E52A50119AE1D61EBC870 /* BackgroundTaskQueue.swift */,
+				593B8209A3E9628B3F079464 /* CrashReporter.swift */,
 				155B3645306233DD226910E8 /* ExternalToolLauncher.swift */,
 				E12BD14A8E992E6A9B4668B7 /* GitCommandExecutor.swift */,
 				8D0B554A7A3F05F099599D36 /* GitHeadMonitor.swift */,
@@ -193,6 +200,7 @@
 				48C7BE2DF5F955131E669BE3 /* AppDelegateColdStartTests.swift */,
 				CA1521E4788D6CDF1C92F4C9 /* BackgroundJobStateTests.swift */,
 				04943FBE79E108AEA932BE7A /* BackgroundTaskQueueTests.swift */,
+				11A6D32025CF2B6E308B21B8 /* CrashReporterTests.swift */,
 				8D4E99B69FBE28C8558EEC50 /* ImportPRViewModelTests.swift */,
 				D17D255D9C03D39E65FC37E5 /* MockGitExecutor.swift */,
 				C9F3D7DAE61099FF17488E05 /* PullRequestInfoTests.swift */,
@@ -322,6 +330,7 @@
 			name = OhMyWorktree;
 			packageProductDependencies = (
 				9C6FD25E01D2C241945E1D05 /* Sparkle */,
+				F8F1840C5D81EAEA407952D8 /* Sentry */,
 			);
 			productName = OhMyWorktree;
 			productReference = AB7DCB0D9BD7764BC9BC08F6 /* OhMyWorktree.app */;
@@ -347,6 +356,7 @@
 			mainGroup = E24E11112DD38BB9817DC8CE;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				40A8866C3D898931BE1278F4 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				02C86F602F1495B106DDAAA6 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -421,6 +431,7 @@
 				454889617A7D8475686FA15A /* AppDelegateColdStartTests.swift in Sources */,
 				0DCEB362F2A309D8F5E5360D /* BackgroundJobStateTests.swift in Sources */,
 				018CEB4BA33463D66FC56390 /* BackgroundTaskQueueTests.swift in Sources */,
+				1F3AD538BC02934BE5D185D5 /* CrashReporterTests.swift in Sources */,
 				BF12B0124F855ED64994FC08 /* ImportPRViewModelTests.swift in Sources */,
 				78CA79D990B38BC4BA845726 /* MockGitExecutor.swift in Sources */,
 				A04EF872B11EC64861D1931F /* PullRequestInfoTests.swift in Sources */,
@@ -446,6 +457,7 @@
 				069FE3565BC42960E0CFBDEA /* BackgroundJob.swift in Sources */,
 				0349E56A97431ED05B90B995 /* BackgroundTaskQueue.swift in Sources */,
 				BE5701A4F52B99C834D7ACB5 /* ContentView.swift in Sources */,
+				BA8411A9040864C023E23CD8 /* CrashReporter.swift in Sources */,
 				81182F4E1FD7B88AE6CCD9C2 /* Date+RelativeTime.swift in Sources */,
 				1D5329DDE42009E76C2650C5 /* ExternalToolLauncher.swift in Sources */,
 				D13B27C586A4730DF2924206 /* GitCommandExecutor.swift in Sources */,
@@ -735,6 +747,14 @@
 				minimumVersion = 2.6.0;
 			};
 		};
+		40A8866C3D898931BE1278F4 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.40.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -742,6 +762,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 02C86F602F1495B106DDAAA6 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		F8F1840C5D81EAEA407952D8 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40A8866C3D898931BE1278F4 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/OhMyWorktree/OhMyWorktreeApp.swift
+++ b/OhMyWorktree/OhMyWorktreeApp.swift
@@ -7,6 +7,11 @@ struct OhMyWorktreeApp: App {
     @StateObject private var worktreeViewModel = WorktreeListViewModel()
     @StateObject private var updaterManager = UpdaterManager()
 
+    init() {
+        let config = CrashReporterConfiguration.fromEnvironment()
+        CrashReporterProvider.shared.start(dsn: config.dsn)
+    }
+
     var body: some Scene {
         // Connect view models to AppDelegate during Scene body evaluation,
         // so the menu bar works even if the main window hasn't appeared yet

--- a/OhMyWorktree/Services/CrashReporter.swift
+++ b/OhMyWorktree/Services/CrashReporter.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+// MARK: - Protocol
+
+/// Abstraction for crash reporting and error tracking.
+/// Enables dependency injection and testability via mock implementations.
+protocol CrashReporter {
+    /// Initialize the crash reporter with the given DSN.
+    func start(dsn: String)
+
+    /// Capture an error with optional contextual metadata.
+    func capture(error: Error, context: [String: Any])
+
+    /// Add a breadcrumb for navigation/audit trail.
+    func addBreadcrumb(message: String, category: String)
+}
+
+// MARK: - Configuration
+
+struct CrashReporterConfiguration {
+    let dsn: String
+
+    /// Default configuration using a placeholder DSN.
+    /// Replace with a real DSN before production use.
+    static let `default` = CrashReporterConfiguration(
+        dsn: "https://examplePublicKey@o0.ingest.sentry.io/0"
+    )
+
+    /// Reads DSN from the `SENTRY_DSN` environment variable,
+    /// falling back to the default placeholder if not set.
+    static func fromEnvironment() -> CrashReporterConfiguration {
+        if let envDSN = ProcessInfo.processInfo.environment["SENTRY_DSN"],
+           !envDSN.isEmpty {
+            return CrashReporterConfiguration(dsn: envDSN)
+        }
+        return .default
+    }
+}
+
+// MARK: - Sentry Implementation
+
+import Sentry
+
+/// Production crash reporter backed by the Sentry SDK.
+final class SentryCrashReporter: CrashReporter {
+
+    func start(dsn: String) {
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.enableAutoSessionTracking = true
+            options.enableCrashHandler = true
+            // Attach stack traces to captured errors for richer diagnostics.
+            options.attachStacktrace = true
+            #if DEBUG
+            options.debug = true
+            options.environment = "development"
+            #else
+            options.environment = "production"
+            #endif
+        }
+    }
+
+    func capture(error: Error, context: [String: Any]) {
+        SentrySDK.capture(error: error) { scope in
+            for (key, value) in context {
+                scope.setExtra(value: value, key: key)
+            }
+        }
+    }
+
+    func addBreadcrumb(message: String, category: String) {
+        let crumb = Breadcrumb(level: .info, category: category)
+        crumb.message = message
+        SentrySDK.addBreadcrumb(crumb)
+    }
+}
+
+// MARK: - No-Op Implementation
+
+/// A crash reporter that does nothing. Useful as a default when
+/// crash reporting is not configured or during testing.
+final class NoOpCrashReporter: CrashReporter {
+    func start(dsn: String) {}
+    func capture(error: Error, context: [String: Any]) {}
+    func addBreadcrumb(message: String, category: String) {}
+}
+
+// MARK: - Global Provider
+
+/// Thread-safe global provider for the crash reporter instance.
+/// Avoids circular static initialization between `OhMyWorktreeApp` and `RepositoryStore`.
+enum CrashReporterProvider {
+    /// The app-wide crash reporter. Defaults to `SentryCrashReporter`.
+    /// Set early in the app lifecycle (e.g., from `OhMyWorktreeApp.init`).
+    static var shared: CrashReporter = SentryCrashReporter()
+}

--- a/OhMyWorktree/Services/RepositoryStore.swift
+++ b/OhMyWorktree/Services/RepositoryStore.swift
@@ -4,6 +4,10 @@ import os
 actor RepositoryStore {
     static let shared = RepositoryStore()
 
+    /// Crash reporter for capturing errors that would otherwise be silently swallowed.
+    /// Defaults to the app-wide reporter; tests can inject a no-op or mock.
+    nonisolated let crashReporter: CrashReporter
+
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.ohmyworktree",
         category: "RepositoryStore"
@@ -41,14 +45,23 @@ actor RepositoryStore {
 
     // MARK: - Initialization
 
-    private init() {
+    private init(crashReporter: CrashReporter? = nil) {
+        self.crashReporter = crashReporter ?? CrashReporterProvider.shared
         // Compute URLs locally — nonisolated computed properties reference `self`,
         // which cannot be used before all stored properties are initialized.
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let storageDir = appSupport.appendingPathComponent("OhMyWorktree", isDirectory: true)
 
         if !FileManager.default.fileExists(atPath: storageDir.path) {
-            try? FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
+            do {
+                try FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
+            } catch {
+                Self.logger.error("Failed to create storage directory: \(error.localizedDescription)")
+                self.crashReporter.capture(error: error, context: [
+                    "operation": "createStorageDirectory",
+                    "path": storageDir.path
+                ])
+            }
         }
 
         let decoder = JSONDecoder()
@@ -57,17 +70,22 @@ actor RepositoryStore {
         // Load into locals first, then assign to self in three definite-initialization
         // writes at the end. Swift 6 permits `self.x = value` in a nonisolated actor
         // init only when it is the *first* (definite) assignment to that property.
+        let reporter = self.crashReporter
+        reporter.addBreadcrumb(message: "Loading persisted data from disk", category: "persistence")
+
         let loadedRepos: [Repository] = Self.loadJSON(
             from: storageDir.appendingPathComponent("repositories.json"),
             type: [Repository].self,
-            decoder: decoder
+            decoder: decoder,
+            crashReporter: reporter
         ) ?? []
 
         var loadedMetadata: [UUID: [WorktreeMetadata]] = [:]
         if let decoded: [String: [WorktreeMetadata]] = Self.loadJSON(
             from: storageDir.appendingPathComponent("worktree_metadata.json"),
             type: [String: [WorktreeMetadata]].self,
-            decoder: decoder
+            decoder: decoder,
+            crashReporter: reporter
         ) {
             for (key, value) in decoded {
                 if let uuid = UUID(uuidString: key) { loadedMetadata[uuid] = value }
@@ -78,7 +96,8 @@ actor RepositoryStore {
         if let decoded: [String: Bool] = Self.loadJSON(
             from: storageDir.appendingPathComponent("env_copy_overrides.json"),
             type: [String: Bool].self,
-            decoder: decoder
+            decoder: decoder,
+            crashReporter: reporter
         ) {
             for (key, value) in decoded {
                 if let uuid = UUID(uuidString: key) { loadedOverrides[uuid] = value }
@@ -98,22 +117,38 @@ actor RepositoryStore {
     private static func loadJSON<T: Decodable>(
         from url: URL,
         type: T.Type,
-        decoder: JSONDecoder
+        decoder: JSONDecoder,
+        crashReporter: CrashReporter
     ) -> T? {
         // 1st: try the primary file
-        if let data = try? Data(contentsOf: url),
-           let decoded = try? decoder.decode(T.self, from: data) {
-            return decoded
+        var primaryError: Error?
+        do {
+            let data = try Data(contentsOf: url)
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            primaryError = error
         }
 
         // 2nd: try the .backup file
         let backupURL = url.appendingPathExtension("backup")
-        if let data = try? Data(contentsOf: backupURL),
-           let decoded = try? decoder.decode(T.self, from: data) {
-            return decoded
+        do {
+            let data = try Data(contentsOf: backupURL)
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            // Both failed — report if the primary file existed (not a first-launch scenario)
+            let fileExists = FileManager.default.fileExists(atPath: url.path)
+                || FileManager.default.fileExists(atPath: backupURL.path)
+            if fileExists {
+                logger.error("Failed to load \(url.lastPathComponent) from primary and backup")
+                crashReporter.capture(error: error, context: [
+                    "operation": "loadJSON",
+                    "file": url.lastPathComponent,
+                    "primaryError": primaryError?.localizedDescription ?? "unknown",
+                    "backupError": error.localizedDescription
+                ])
+            }
         }
 
-        // Both failed — return nil (first launch or unrecoverable)
         return nil
     }
 
@@ -225,6 +260,11 @@ actor RepositoryStore {
     private func saveToDisk() {
         guard dirtyRepos || dirtyMetadata || dirtyOverrides else { return }
 
+        crashReporter.addBreadcrumb(
+            message: "Saving to disk (repos=\(dirtyRepos), meta=\(dirtyMetadata), overrides=\(dirtyOverrides))",
+            category: "persistence"
+        )
+
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = .prettyPrinted
@@ -232,30 +272,51 @@ actor RepositoryStore {
         // Only encode and write data that was actually modified.
         // Clear dirty flag only on successful write so failures are retried.
         if dirtyRepos {
-            if let data = try? encoder.encode(repositories) {
+            do {
+                let data = try encoder.encode(repositories)
                 if atomicWrite(data: data, to: repositoriesFileURL) {
                     dirtyRepos = false
                 }
+            } catch {
+                Self.logger.error("Failed to encode repositories: \(error.localizedDescription)")
+                crashReporter.capture(error: error, context: [
+                    "operation": "encodeRepositories",
+                    "count": repositories.count
+                ])
             }
         }
         if dirtyMetadata {
             let stringKeyed = Dictionary(
                 uniqueKeysWithValues: worktreeMetadata.map { ($0.key.uuidString, $0.value) }
             )
-            if let data = try? encoder.encode(stringKeyed) {
+            do {
+                let data = try encoder.encode(stringKeyed)
                 if atomicWrite(data: data, to: metadataFileURL) {
                     dirtyMetadata = false
                 }
+            } catch {
+                Self.logger.error("Failed to encode metadata: \(error.localizedDescription)")
+                crashReporter.capture(error: error, context: [
+                    "operation": "encodeMetadata",
+                    "count": worktreeMetadata.count
+                ])
             }
         }
         if dirtyOverrides {
             let stringKeyed = Dictionary(
                 uniqueKeysWithValues: envCopyOverrides.map { ($0.key.uuidString, $0.value) }
             )
-            if let data = try? encoder.encode(stringKeyed) {
+            do {
+                let data = try encoder.encode(stringKeyed)
                 if atomicWrite(data: data, to: envCopyOverridesFileURL) {
                     dirtyOverrides = false
                 }
+            } catch {
+                Self.logger.error("Failed to encode overrides: \(error.localizedDescription)")
+                crashReporter.capture(error: error, context: [
+                    "operation": "encodeOverrides",
+                    "count": envCopyOverrides.count
+                ])
             }
         }
     }
@@ -283,6 +344,10 @@ actor RepositoryStore {
             return true
         } catch {
             Self.logger.error("Failed to write \(destinationURL.lastPathComponent): \(error.localizedDescription)")
+            crashReporter.capture(error: error, context: [
+                "operation": "atomicWrite",
+                "file": destinationURL.lastPathComponent
+            ])
             try? fm.removeItem(at: tempURL)
             return false
         }

--- a/OhMyWorktreeTests/CrashReporterTests.swift
+++ b/OhMyWorktreeTests/CrashReporterTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+
+@testable import OhMyWorktree
+
+// MARK: - Mock
+
+final class MockCrashReporter: CrashReporter {
+    private(set) var startedWithDSN: String?
+    private(set) var capturedErrors: [(error: Error, context: [String: Any])] = []
+    private(set) var breadcrumbs: [(message: String, category: String)] = []
+
+    func start(dsn: String) {
+        startedWithDSN = dsn
+    }
+
+    func capture(error: Error, context: [String: Any]) {
+        capturedErrors.append((error: error, context: context))
+    }
+
+    func addBreadcrumb(message: String, category: String) {
+        breadcrumbs.append((message: message, category: category))
+    }
+}
+
+// MARK: - CrashReporter Protocol Tests
+
+final class CrashReporterTests: XCTestCase {
+
+    private var sut: MockCrashReporter!
+
+    override func setUp() {
+        super.setUp()
+        sut = MockCrashReporter()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initialization
+
+    func testStartSetsCorrectDSN() {
+        let dsn = "https://examplePublicKey@o0.ingest.sentry.io/0"
+        sut.start(dsn: dsn)
+        XCTAssertEqual(sut.startedWithDSN, dsn)
+    }
+
+    func testStartCanBeCalledMultipleTimes() {
+        sut.start(dsn: "dsn1")
+        sut.start(dsn: "dsn2")
+        XCTAssertEqual(sut.startedWithDSN, "dsn2")
+    }
+
+    // MARK: - Error Capture
+
+    func testCaptureErrorRecordsError() {
+        let error = OhMyWorktreeError.repositoryNotFound
+        sut.capture(error: error, context: ["operation": "load"])
+
+        XCTAssertEqual(sut.capturedErrors.count, 1)
+        XCTAssertEqual(
+            sut.capturedErrors.first?.error.localizedDescription,
+            error.localizedDescription
+        )
+    }
+
+    func testCaptureErrorPreservesContext() {
+        let error = OhMyWorktreeError.invalidPath(path: "/tmp/test")
+        let context: [String: Any] = ["file": "repositories.json", "operation": "save"]
+        sut.capture(error: error, context: context)
+
+        XCTAssertEqual(sut.capturedErrors.first?.context["file"] as? String, "repositories.json")
+        XCTAssertEqual(sut.capturedErrors.first?.context["operation"] as? String, "save")
+    }
+
+    func testCaptureMultipleErrors() {
+        sut.capture(error: OhMyWorktreeError.repositoryNotFound, context: [:])
+        sut.capture(error: OhMyWorktreeError.gitNotInstalled, context: [:])
+        sut.capture(
+            error: OhMyWorktreeError.permissionDenied(path: "/test"),
+            context: ["severity": "high"]
+        )
+
+        XCTAssertEqual(sut.capturedErrors.count, 3)
+    }
+
+    // MARK: - Breadcrumbs
+
+    func testAddBreadcrumbRecordsMessage() {
+        sut.addBreadcrumb(message: "Loading repositories", category: "persistence")
+
+        XCTAssertEqual(sut.breadcrumbs.count, 1)
+        XCTAssertEqual(sut.breadcrumbs.first?.message, "Loading repositories")
+        XCTAssertEqual(sut.breadcrumbs.first?.category, "persistence")
+    }
+
+    func testAddMultipleBreadcrumbs() {
+        sut.addBreadcrumb(message: "Started save", category: "persistence")
+        sut.addBreadcrumb(message: "Encoded data", category: "persistence")
+        sut.addBreadcrumb(message: "Wrote to disk", category: "io")
+
+        XCTAssertEqual(sut.breadcrumbs.count, 3)
+        XCTAssertEqual(sut.breadcrumbs[0].message, "Started save")
+        XCTAssertEqual(sut.breadcrumbs[1].message, "Encoded data")
+        XCTAssertEqual(sut.breadcrumbs[2].category, "io")
+    }
+
+    // MARK: - CrashReporterConfiguration
+
+    func testConfigurationDefaultDSN() {
+        let config = CrashReporterConfiguration.default
+        XCTAssertFalse(config.dsn.isEmpty, "Default DSN should not be empty")
+    }
+
+    func testConfigurationCustomDSN() {
+        let customDSN = "https://custom@sentry.io/123"
+        let config = CrashReporterConfiguration(dsn: customDSN)
+        XCTAssertEqual(config.dsn, customDSN)
+    }
+
+    func testConfigurationEnvironmentVariable() {
+        let envDSN = ProcessInfo.processInfo.environment["SENTRY_DSN"]
+        let config = CrashReporterConfiguration.fromEnvironment()
+        if let envDSN {
+            XCTAssertEqual(config.dsn, envDSN)
+        } else {
+            XCTAssertEqual(config.dsn, CrashReporterConfiguration.default.dsn)
+        }
+    }
+
+    // MARK: - SentryCrashReporter Initialization
+
+    func testSentryCrashReporterConformsToProtocol() {
+        let reporter: CrashReporter = SentryCrashReporter()
+        // Verify type conformance — the compiler enforces this, but it's
+        // good to have an explicit runtime check.
+        XCTAssertTrue(reporter is SentryCrashReporter)
+    }
+
+    // MARK: - Protocol Conformance as Dependency
+
+    func testMockCanBeUsedAsDependency() {
+        let mock = MockCrashReporter()
+        let reporter: CrashReporter = mock
+
+        reporter.start(dsn: "test-dsn")
+        reporter.addBreadcrumb(message: "test", category: "test")
+        reporter.capture(error: OhMyWorktreeError.gitNotInstalled, context: [:])
+
+        XCTAssertEqual(mock.startedWithDSN, "test-dsn")
+        XCTAssertEqual(mock.breadcrumbs.count, 1)
+        XCTAssertEqual(mock.capturedErrors.count, 1)
+    }
+
+    // MARK: - NoOpCrashReporter
+
+    func testNoOpReporterDoesNotCrash() {
+        let reporter = NoOpCrashReporter()
+        reporter.start(dsn: "anything")
+        reporter.addBreadcrumb(message: "ignored", category: "test")
+        reporter.capture(error: OhMyWorktreeError.gitNotInstalled, context: ["key": "value"])
+        // If we get here without crashing, the test passes
+    }
+
+    // MARK: - CrashReporterProvider
+
+    func testProviderReturnsReporter() {
+        let reporter = CrashReporterProvider.shared
+        XCTAssertTrue(reporter is SentryCrashReporter)
+    }
+
+    func testProviderCanBeOverridden() {
+        let original = CrashReporterProvider.shared
+        let mock = MockCrashReporter()
+        CrashReporterProvider.shared = mock
+
+        XCTAssertTrue(CrashReporterProvider.shared is MockCrashReporter)
+
+        // Restore original
+        CrashReporterProvider.shared = original
+    }
+}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1205,6 +1205,32 @@ let nouns = ["ocean", "river", "mountain", "forest", "sky", "lunch", "pizza", ..
 
 ---
 
+#### FR-036: Error Tracking — Sentry Integration (P1)
+
+**설명**: Sentry SDK를 통합하여 크래시 리포팅 및 에러 트래킹 인프라를 구축. 현재 `RepositoryStore` 등 핵심 경로에서 조용히 무시되는(`try?`) 에러를 캡처하여 프로덕션 안정성 모니터링을 가능하게 함.
+
+**상세 요구사항**:
+- `CrashReporter` 프로토콜 정의: `start(dsn:)`, `capture(error:context:)`, `addBreadcrumb(message:category:)` 메서드
+- `SentryCrashReporter`: Sentry SDK를 사용한 프로토콜 구현체
+- 프로토콜 기반 설계로 테스트 시 Mock 주입 가능
+- 앱 시작 시(`OhMyWorktreeApp`) Sentry 초기화
+- DSN은 하드코딩하지 않고 설정 기반 접근 (환경변수 또는 Config)
+- `RepositoryStore`의 silent `try?` 블록에 에러 캡처 추가:
+  - `atomicWrite` catch 블록
+  - `loadJSON` 1차/백업 모두 실패 시
+  - 디렉토리 생성 실패 시
+  - 인코딩 실패 시
+- 주요 작업에 breadcrumb 추가 (저장, 로드, 삭제 등)
+
+**영향받는 컴포넌트**:
+- `CrashReporter` (새 프로토콜)
+- `SentryCrashReporter` (새 구현체)
+- `OhMyWorktreeApp` (초기화)
+- `RepositoryStore` (에러 캡처 추가)
+- `project.yml` (Sentry SPM 패키지 추가)
+
+---
+
 ## 6. 비기능 요구사항
 
 ### 6.1 성능 요구사항

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,9 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     from: "2.6.0"
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    from: "8.40.0"
 
 settings:
   SWIFT_VERSION: "5.9"
@@ -25,6 +28,7 @@ targets:
       - OhMyWorktree
     dependencies:
       - package: Sparkle
+      - package: Sentry
     preBuildScripts:
       - name: SwiftLint
         script: |


### PR DESCRIPTION
## Summary

- Add `CrashReporter` protocol with `SentryCrashReporter` (Sentry SDK) and `NoOpCrashReporter` implementations for testability via dependency injection
- Replace silent `try?` blocks in `RepositoryStore` with proper error capture: directory creation, JSON loading (primary + backup), encoding, and atomic writes
- Add breadcrumb tracking for persistence operations (load, save) to aid debugging
- DSN is configurable via `SENTRY_DSN` environment variable (placeholder default for development)
- Add FR-036 to PRD documenting the feature requirements

Closes #3

> **Note**: The DSN placeholder (`https://examplePublicKey@o0.ingest.sentry.io/0`) must be replaced with a real Sentry project DSN before production use. Set the `SENTRY_DSN` environment variable or update `CrashReporterConfiguration.default`.

## Test plan

- [x] 15 new unit tests in `CrashReporterTests.swift` covering:
  - Protocol conformance (start, capture, breadcrumbs)
  - Error context preservation
  - Configuration (default DSN, custom DSN, environment variable)
  - `SentryCrashReporter` type conformance
  - `NoOpCrashReporter` safety
  - `CrashReporterProvider` global override
  - Mock injection as dependency
- [x] All 224 existing tests pass with zero failures
- [x] SwiftLint: 0 violations
- [ ] Verify Sentry events appear in dashboard after configuring a real DSN

🤖 Generated with [Claude Code](https://claude.com/claude-code)