### PR TITLE
Fix PR import failure when orphaned local branch exists

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		59C9E6B4357FF5942927E09E /* ImportPRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A03AD181020CC2A2003500 /* ImportPRView.swift */; };
 		5A71C946790D3FAAC3B2AF80 /* RepositoryListViewModelNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF799E855838610F7B5E4345 /* RepositoryListViewModelNavigationTests.swift */; };
 		5FF69FC201062F843B4C9297 /* WorktreeListViewModel+ExternalTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E110EB7715E49CA580231B2 /* WorktreeListViewModel+ExternalTools.swift */; };
+		6037CFB045743E19F0AEA30A /* WorktreeManagerRemoteBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D47F034CB7C89712C2CACFD /* WorktreeManagerRemoteBranchTests.swift */; };
 		638E6CA1194A56DF7C449566 /* WindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C843B3047D22F1A56EAE0AFB /* WindowObserver.swift */; };
 		653587B67AD671EEE36C6C93 /* OhMyWorktreeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCCF64227A4F11AF7BA80B6 /* OhMyWorktreeError.swift */; };
 		671DEF7953036D7C339F1C16 /* WorktreeFileCopierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E90BF743990ABDF5F54752 /* WorktreeFileCopierTests.swift */; };
@@ -143,6 +144,7 @@
 		96935A42D04223A55B9D710D /* AppDelegate+Window.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Window.swift"; sourceTree = "<group>"; };
 		9BBF676DB7A8AE7653B7EC55 /* UpdatesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatesSettingsView.swift; sourceTree = "<group>"; };
 		9BD25714038218BA848A16DA /* WorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeTests.swift; sourceTree = "<group>"; };
+		9D47F034CB7C89712C2CACFD /* WorktreeManagerRemoteBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeManagerRemoteBranchTests.swift; sourceTree = "<group>"; };
 		9E4573C30ACEBDEC8AE2233B /* ShortcutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutManager.swift; sourceTree = "<group>"; };
 		A200952D514CDC6E761D7D31 /* RandomNameGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomNameGenerator.swift; sourceTree = "<group>"; };
 		A2A39FCA55BDC5AFC0131335 /* WorktreeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeManagerTests.swift; sourceTree = "<group>"; };
@@ -254,6 +256,7 @@
 				F6949AB98960591D37ABCC59 /* WorktreeListViewModelImportTests.swift */,
 				6460930465C1945BB9E708A7 /* WorktreeListViewModelSelectionTests.swift */,
 				ABF450885A0658CB279EE089 /* WorktreeListViewModelTests.swift */,
+				9D47F034CB7C89712C2CACFD /* WorktreeManagerRemoteBranchTests.swift */,
 				A2A39FCA55BDC5AFC0131335 /* WorktreeManagerTests.swift */,
 				1E37907BD97EF1278CAD9A1B /* WorktreeMetadataTests.swift */,
 				9BD25714038218BA848A16DA /* WorktreeTests.swift */,
@@ -497,6 +500,7 @@
 				8C7C7074832657257E597751 /* WorktreeListViewModelImportTests.swift in Sources */,
 				3E3BC079BCB09601CF331D43 /* WorktreeListViewModelSelectionTests.swift in Sources */,
 				80092B38847E833C625A2FC9 /* WorktreeListViewModelTests.swift in Sources */,
+				6037CFB045743E19F0AEA30A /* WorktreeManagerRemoteBranchTests.swift in Sources */,
 				7DC6228DB15054EE52B4F8CB /* WorktreeManagerTests.swift in Sources */,
 				150BA7D5A0121054A1307FF1 /* WorktreeMetadataTests.swift in Sources */,
 				14E42FFD99B49D00630EA203 /* WorktreeTests.swift in Sources */,

--- a/OhMyWorktree/Services/WorktreeManager.swift
+++ b/OhMyWorktree/Services/WorktreeManager.swift
@@ -156,6 +156,9 @@ final class WorktreeManager: Sendable {
 
     /// Creates a worktree with a brand-new local branch (`localBranch`) starting at
     /// the given `startPoint` (defaults to `origin/<remoteBranch>`).
+    ///
+    /// If the local branch already exists (e.g. orphaned after a previous worktree
+    /// removal), falls back to checking out the existing branch without `-b`.
     func addWorktreeFromRemoteBranch(
         repositoryPath: String,
         folderName: String,
@@ -181,8 +184,19 @@ final class WorktreeManager: Sendable {
             workingDirectory: repositoryPath
         )
 
-        guard result.exitCode == 0 else {
+        if result.exitCode != 0 {
             let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // GitHub #23: An orphaned local branch (left behind after worktree removal)
+            // causes `-b` to fail. Fall back to checking out the existing branch.
+            if stderr.contains("already exists") {
+                return try await addWorktreeFromExistingBranch(
+                    repositoryPath: repositoryPath,
+                    folderName: folderName,
+                    branch: localBranch
+                )
+            }
+
             throw OhMyWorktreeError.commandExecutionFailed(command: "git worktree add", stderr: stderr)
         }
 

--- a/OhMyWorktreeTests/WorktreeManagerRemoteBranchTests.swift
+++ b/OhMyWorktreeTests/WorktreeManagerRemoteBranchTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+
+@testable import OhMyWorktree
+
+// MARK: - Handler-based Mock
+
+/// Handler-based mock that returns different results based on the git arguments.
+private final class HandlerMockGitExecutor: GitCommandExecuting, @unchecked Sendable {
+    var executedCommands: [[String]] = []
+    var handler: (([String]) -> CommandResult)?
+
+    func execute(command: String, arguments: [String], workingDirectory: String?) async throws -> CommandResult {
+        executedCommands.append(arguments)
+        return handler?(arguments) ?? CommandResult(stdout: "", stderr: "", exitCode: 0)
+    }
+}
+
+// MARK: - addWorktreeFromRemoteBranch Orphaned Branch Tests (GitHub #23)
+
+final class WorktreeManagerRemoteBranchTests: XCTestCase {
+
+    private var mock: HandlerMockGitExecutor!
+    private var sut: WorktreeManager!
+    private var expectedPath: String!
+
+    override func setUp() {
+        super.setUp()
+        mock = HandlerMockGitExecutor()
+        sut = WorktreeManager(executor: mock, fileManager: MockNoOpFileManager())
+        expectedPath = WorktreeManager.worktreePath(repositoryPath: "/tmp/repo", folderName: "bright-ocean")
+    }
+
+    private func worktreeListOutput(path: String) -> String {
+        """
+        worktree \(path)
+        HEAD deadbeef
+        branch refs/heads/fix/foo
+
+        """
+    }
+
+    // MARK: - Fallback when local branch already exists
+
+    func testAddWorktreeFromRemoteBranch_branchAlreadyExists_fallsBackToExistingBranch() async throws {
+        mock.handler = { [expectedPath] args in
+            // First call: `git worktree add -b fix/foo <path> <startPoint>` → fails
+            if args.contains("-b") && args.contains("fix/foo") {
+                return CommandResult(
+                    stdout: "",
+                    stderr: "fatal: a branch named 'fix/foo' already exists",
+                    exitCode: 128
+                )
+            }
+            // Second call: `git worktree add <path> fix/foo` → succeeds
+            if args.first == "worktree" && args.contains("add") && !args.contains("-b") {
+                return CommandResult(stdout: "", stderr: "", exitCode: 0)
+            }
+            // Third call: `git worktree list --porcelain` → returns the new worktree
+            if args == ["worktree", "list", "--porcelain"] {
+                return CommandResult(stdout: self.worktreeListOutput(path: expectedPath!), stderr: "", exitCode: 0)
+            }
+            return CommandResult(stdout: "", stderr: "", exitCode: 0)
+        }
+
+        let worktree = try await sut.addWorktreeFromRemoteBranch(
+            repositoryPath: "/tmp/repo",
+            folderName: "bright-ocean",
+            localBranch: "fix/foo",
+            remoteBranch: "fix/foo",
+            startPoint: "refs/omw/pr/10"
+        )
+
+        XCTAssertEqual(worktree.branch, "fix/foo")
+
+        // Verify the fallback command was issued (without -b)
+        let fallbackCommand = mock.executedCommands.first { args in
+            args.first == "worktree" && args.contains("add") && !args.contains("-b") && args.contains("fix/foo")
+        }
+        XCTAssertNotNil(fallbackCommand, "Expected a fallback 'git worktree add <path> <branch>' without -b")
+    }
+
+    func testAddWorktreeFromRemoteBranch_otherError_throwsWithoutRetry() async {
+        mock.handler = { args in
+            if args.contains("-b") {
+                return CommandResult(
+                    stdout: "",
+                    stderr: "fatal: '<path>' is not a valid path",
+                    exitCode: 128
+                )
+            }
+            if args == ["worktree", "list", "--porcelain"] {
+                return CommandResult(stdout: "", stderr: "", exitCode: 0)
+            }
+            return CommandResult(stdout: "", stderr: "", exitCode: 0)
+        }
+
+        await XCTAssertThrowsErrorAsync(
+            try await sut.addWorktreeFromRemoteBranch(
+                repositoryPath: "/tmp/repo",
+                folderName: "bright-ocean",
+                localBranch: "fix/foo",
+                remoteBranch: "fix/foo",
+                startPoint: "refs/omw/pr/10"
+            )
+        )
+
+        // Should NOT attempt a fallback for non-"already exists" errors
+        let fallbackCommand = mock.executedCommands.first { args in
+            args.first == "worktree" && args.contains("add") && !args.contains("-b")
+        }
+        XCTAssertNil(fallbackCommand, "Should not retry with fallback for non-branch-exists errors")
+    }
+
+    func testAddWorktreeFromRemoteBranch_noBranchConflict_usesCreateBranch() async throws {
+        mock.handler = { [expectedPath] args in
+            if args == ["worktree", "list", "--porcelain"] {
+                return CommandResult(stdout: self.worktreeListOutput(path: expectedPath!), stderr: "", exitCode: 0)
+            }
+            // All commands succeed (including -b)
+            return CommandResult(stdout: "", stderr: "", exitCode: 0)
+        }
+
+        let worktree = try await sut.addWorktreeFromRemoteBranch(
+            repositoryPath: "/tmp/repo",
+            folderName: "bright-ocean",
+            localBranch: "fix/foo",
+            remoteBranch: "fix/foo",
+            startPoint: "refs/omw/pr/10"
+        )
+
+        XCTAssertEqual(worktree.branch, "fix/foo")
+
+        // Should use -b (create branch), not fallback
+        let createBranchCommand = mock.executedCommands.first { args in
+            args.contains("-b") && args.contains("fix/foo")
+        }
+        XCTAssertNotNil(createBranchCommand, "Should use -b to create a new branch when none exists")
+
+        // Should NOT have a fallback command
+        let fallbackCommand = mock.executedCommands.first { args in
+            args.first == "worktree" && args.contains("add") && !args.contains("-b") && args.contains("fix/foo")
+        }
+        XCTAssertNil(fallbackCommand, "Should not issue fallback when -b succeeds")
+    }
+}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -810,6 +810,11 @@ branch refs/heads/feature/new-feature
   - 동일 PR 브랜치가 이미 checkout된 경우 버전 접미사 자동 생성 (예: `feature/foo-v2`, `-v3`)
   - 기존 worktree 브랜치 + 큐에 대기 중인 작업 브랜치 모두 충돌 검사
   - 충돌 검사 스코프: 리포지토리별 (`repositoryID`)
+- **고아 로컬 브랜치 처리** (Bug Fix — GitHub #23):
+  - Worktree 삭제 후 남아있는 고아 로컬 브랜치로 인한 PR Import 실패 해결
+  - `addWorktreeFromRemoteBranch`에서 `git worktree add -b`가 "already exists" 에러로 실패 시, `-b` 없이 기존 로컬 브랜치를 체크아웃하는 방식으로 폴백
+  - 폴백 시 `git worktree add <path> <existing-branch>` 사용 (기존 브랜치 포인터 유지)
+  - `-b` 이외의 에러는 기존과 동일하게 전파
 - **PR 배지 연동**:
   - Import된 worktree의 메타데이터에 `prRemoteBranch` 저장
   - PR 배지 매칭 시 `worktree.branch` → `worktree.prRemoteBranch` 폴백 (FR-028)


### PR DESCRIPTION
## Summary
- Fixes #23
- When `git worktree add -b` fails with "already exists" (orphaned local branch from a previously removed worktree), fall back to `git worktree add <path> <branch>` to check out the existing branch
- Other errors continue to propagate as before

## Changes
- **`WorktreeManager.swift`** — `addWorktreeFromRemoteBranch()` now catches "already exists" errors and delegates to `addWorktreeFromExistingBranch()`
- **`WorktreeManagerRemoteBranchTests.swift`** (new) — 3 tests covering fallback, error propagation, and happy path
- **`docs/PRD.md`** — Added orphaned branch handling documentation to FR-035

## Test plan
- [x] `testAddWorktreeFromRemoteBranch_branchAlreadyExists_fallsBackToExistingBranch` — verifies fallback to existing branch checkout
- [x] `testAddWorktreeFromRemoteBranch_otherError_throwsWithoutRetry` — verifies non-branch errors still throw
- [x] `testAddWorktreeFromRemoteBranch_noBranchConflict_usesCreateBranch` — verifies normal `-b` path unchanged
- [x] Full test suite: 234 tests, 0 failures
- [x] SwiftLint: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)