### PR TITLE
Add ⌘P / ⌘O / ⌘C shortcuts for Git Pull, Show in Finder, Copy Path

### DIFF
--- a/OhMyWorktree/Models/ShortcutAction.swift
+++ b/OhMyWorktree/Models/ShortcutAction.swift
@@ -15,6 +15,9 @@ enum ShortcutAction: String, CaseIterable {
     case openCursor
     case openCmux
     case refreshWorktrees
+    case gitPull
+    case showInFinder
+    case copyPath
 
     /// The default key combo string for this action.
     var defaultCombo: String {
@@ -32,6 +35,9 @@ enum ShortcutAction: String, CaseIterable {
         case .openCursor: "⌘⇧C"
         case .openCmux: "⌘⇧M"
         case .refreshWorktrees: "⌘R"
+        case .gitPull: "⌘P"
+        case .showInFinder: "⌘O"
+        case .copyPath: "⌘C"
         }
     }
 
@@ -56,6 +62,9 @@ enum ShortcutAction: String, CaseIterable {
         case .openCursor: "Open in Cursor"
         case .openCmux: "Open in cmux"
         case .refreshWorktrees: "Refresh Worktrees"
+        case .gitPull: "Git Pull"
+        case .showInFinder: "Show in Finder"
+        case .copyPath: "Copy Path"
         }
     }
 

--- a/OhMyWorktree/Views/WorktreeListView.swift
+++ b/OhMyWorktree/Views/WorktreeListView.swift
@@ -207,18 +207,18 @@ struct WorktreeListView: View {
 
         if !worktree.isBare {
             Divider()
-            Button("Git Pull") { viewModel.gitPull(worktree) }
+            contextMenuButton("Git Pull", action: .gitPull) { viewModel.gitPull(worktree) }
                 .disabled(!actions.canGitPull)
         }
 
         Divider()
 
-        Button("Show in Finder") {
+        contextMenuButton("Show in Finder", action: .showInFinder) {
             NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
         }
         .disabled(!actions.canShowInFinder)
 
-        Button("Copy Path") {
+        contextMenuButton("Copy Path", action: .copyPath) {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(worktree.path, forType: .string)
         }

--- a/OhMyWorktreeTests/ShortcutActionTests.swift
+++ b/OhMyWorktreeTests/ShortcutActionTests.swift
@@ -44,7 +44,10 @@ struct ShortcutActionTests {
         (.openVSCode, "⌘⇧V"),
         (.openCursor, "⌘⇧C"),
         (.openCmux, "⌘⇧M"),
-        (.refreshWorktrees, "⌘R")
+        (.refreshWorktrees, "⌘R"),
+        (.gitPull, "⌘P"),
+        (.showInFinder, "⌘O"),
+        (.copyPath, "⌘C")
     ])
     func specificDefaults(action: ShortcutAction, expectedCombo: String) {
         #expect(action.defaultCombo == expectedCombo)

--- a/OhMyWorktreeTests/ShortcutManagerTests.swift
+++ b/OhMyWorktreeTests/ShortcutManagerTests.swift
@@ -117,6 +117,26 @@ struct ShortcutManagerTests {
         #expect(shortcut.modifiers == [.shift, .command])
     }
 
+    // MARK: - KeyboardShortcut Helper (Worktree Context Actions)
+
+    @Test func keyboardShortcutForAction_commandP_gitPull() throws {
+        let shortcut = try #require(manager.keyboardShortcut(for: .gitPull))
+        #expect(shortcut.key == "p")
+        #expect(shortcut.modifiers == .command)
+    }
+
+    @Test func keyboardShortcutForAction_commandO_showInFinder() throws {
+        let shortcut = try #require(manager.keyboardShortcut(for: .showInFinder))
+        #expect(shortcut.key == "o")
+        #expect(shortcut.modifiers == .command)
+    }
+
+    @Test func keyboardShortcutForAction_commandC_copyPath() throws {
+        let shortcut = try #require(manager.keyboardShortcut(for: .copyPath))
+        #expect(shortcut.key == "c")
+        #expect(shortcut.modifiers == .command)
+    }
+
     // MARK: - Version Counter
 
     @Test func setCombo_incrementsVersion() {

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1206,6 +1206,9 @@ Force Remove Worktree
 | `Cmd+Shift+C` | Cursor에서 열기 |
 | `Cmd+Shift+M` | CMux에서 열기 |
 | `Cmd+R` | 목록 새로고침 |
+| `Cmd+P` | 선택된 worktree에서 Git Pull (bare 제외) |
+| `Cmd+O` | 선택된 worktree를 Finder에 표시 |
+| `Cmd+C` | 선택된 worktree 경로를 클립보드에 복사 |
 
 **키보드 네비게이션**:
 - 메인 윈도우 포커스 시 Worktree 리스트가 자동으로 포커스를 받아야 함
@@ -1226,7 +1229,7 @@ Force Remove Worktree
 **컨텍스트 메뉴 단축키 표기**:
 - Worktree 컨텍스트 메뉴(우클릭)의 각 항목 옆에 해당 단축키 조합 표시
 - 사용자가 Settings에서 단축키를 변경하면 컨텍스트 메뉴 표기도 즉시 반영
-- 대상 항목: Open in iTerm/Ghostty/VSCode/Cursor/cmux, Remove Worktree 등
+- 대상 항목: Open in iTerm/Ghostty/VSCode/Cursor/cmux, Git Pull, Show in Finder, Copy Path, Remove Worktree 등
 
 **단축키 커스터마이징** (Settings > Shortcuts 탭):
 - 모든 단축키(글로벌 핫키 + 인앱 단축키) 변경 가능
@@ -2417,6 +2420,7 @@ end tell
 | 1.2.1 | 2026-02-27 | Worktree 이름 변경 (FR-030) — WorktreeMetadata에 customName 필드 추가, displayName 우선순위 로직 (customName → branch → detached), 인라인 TextField 편집 (Finder 스타일), 컨텍스트 메뉴 Rename 항목, Enter 키 트리거, 빈 문자열로 기본 표기 복귀, JSON 하위호환 | Claude Code |
 | 1.2.2 | 2026-03-09 | 백그라운드 작업 큐 및 다중 선택 일괄 삭제 (FR-031/032/033) — BackgroundTaskQueue (actor 기반), 네이티브 List 다중 선택, 컨텍스트 메뉴 일괄 Remove/Force Remove, QueueStatusBarView, AppDelegate 리팩토링, CI/CD 추가, 보안 수정 + 코드 리뷰 반영 (FR-034): loadWorktrees 이중 경로 제거, busyWorktreeIDs 캐싱(@Published 저장 프로퍼티), 에러 메시지 컨텍스트 추가, Force Remove 확인 다이얼로그, Job 배열 자동 정리(maxFailedJobs=50), macOS 시스템 알림(NotificationManager/UNUserNotificationCenter), 스트레스 테스트 추가 | Claude Code |
 | 1.2.4 | 2026-03-28 | "Quick Remove Worktree" 메뉴 추가 (FR-036) + 타임아웃 설정 (FR-037) — 기존 Remove/Force Remove 유지하면서 `FileManager.trashItem` + `git worktree prune` 방식의 세 번째 삭제 옵션 추가, node_modules 등 대량 파일 프로젝트에서 즉시 삭제 체감, 휴지통을 통한 복구 가능, `BackgroundJobKind.quickRemove` 추가, 다중 선택 일괄 지원; Settings > Advanced에 백그라운드 작업 타임아웃 설정(30~600초) 추가, 타임아웃 에러 메시지에 원인 및 해결 방법 안내 | Claude Code |
+| 1.3.1 | 2026-04-19 | Worktree 컨텍스트 메뉴 단축키 확장 (FR-012) — Git Pull(`⌘P`), Show in Finder(`⌘O`), Copy Path(`⌘C`) 단축키 기본값 추가. `ShortcutAction`에 `gitPull`/`showInFinder`/`copyPath` 케이스 3종 추가, Settings > Shortcuts 탭에서 커스터마이징 가능, 컨텍스트 메뉴에 단축키 조합 자동 표기 | Claude Code |
 
 ---
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -17,6 +17,9 @@ All in-app shortcuts are customizable via **Settings > Shortcuts** (⌘,).
 | ⌘⌫ | Force Remove | Remove even with uncommitted changes |
 | ⇧⌘⌫ | Quick Remove | Move to Trash immediately without checks |
 | ⌘R | Refresh | Reload the worktree list |
+| ⌘P | Git Pull | Run `git pull` in the selected worktree (non-bare only) |
+| ⌘O | Show in Finder | Reveal the selected worktree in Finder |
+| ⌘C | Copy Path | Copy the selected worktree's path to the clipboard |
 | ⏎ | Rename | Edit the selected worktree's name |
 | ⎋ | Clear Selection | Deselect the current worktree |
 


### PR DESCRIPTION
## Summary
- Adds three new configurable in-app shortcuts on the worktree context menu: `⌘P` (Git Pull), `⌘O` (Show in Finder), `⌘C` (Copy Path)
- Extends `ShortcutAction` with `gitPull` / `showInFinder` / `copyPath` cases so the combos appear in **Settings > Shortcuts** and are surfaced next to the matching context menu items
- Updates PRD (FR-012) and `docs/keyboard-shortcuts.md` with the new defaults

## Test plan
- [ ] Right-click a worktree → verify `⌘P`, `⌘O`, `⌘C` appear next to Git Pull, Show in Finder, Copy Path
- [ ] With a worktree selected, press `⌘P` → Git Pull runs (non-bare only)
- [ ] With a worktree selected, press `⌘O` → Finder reveals the folder
- [ ] With a worktree selected, press `⌘C` → path is in the clipboard
- [ ] Open Settings > Shortcuts → three new rows appear and can be re-bound / reset
- [ ] `swiftlint lint` and `xcodebuild test` pass (✅ 328 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)