### PR TITLE
Fix cmux 0.63.2+ compatibility (socket path + send truncation)

### DIFF
--- a/OhMyWorktree.xcodeproj/project.pbxproj
+++ b/OhMyWorktree.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1C1FE0AA00CDDC453D7CD3C9 /* WorktreeManager+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480F07AB9D151580E4392F2C /* WorktreeManager+Parsing.swift */; };
 		1D280B90168CDB181DC5FAE4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73CCA7E1C1ACBAF4E4291EA8 /* Assets.xcassets */; };
 		1D5329DDE42009E76C2650C5 /* ExternalToolLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B3645306233DD226910E8 /* ExternalToolLauncher.swift */; };
+		1E8109BF316BBF3756D84C2D /* ExternalToolLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B891A0806B6FDB6CF884972B /* ExternalToolLauncherTests.swift */; };
 		23D59664983897448C98FDCB /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB917EB3E6DA41526EE7D6D /* TestHelpers.swift */; };
 		24D6FB5B97F04ECE5DC221BF /* WorktreeManager+GitOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B45C279C31CE3F9F048056 /* WorktreeManager+GitOps.swift */; };
 		28AAB167DD6C5B36997EEFDB /* ShortcutsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D6DA2DB9FCC472CF45E5EB /* ShortcutsSettingsView.swift */; };
@@ -167,6 +168,7 @@
 		AFE7A83D915B984C5F6EEEAC /* Worktree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Worktree.swift; sourceTree = "<group>"; };
 		B344DBF698890D1B13BB69D6 /* WorktreeFileCopier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeFileCopier.swift; sourceTree = "<group>"; };
 		B8362992DEC2BA4D89D03E2A /* PullRequestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullRequestService.swift; sourceTree = "<group>"; };
+		B891A0806B6FDB6CF884972B /* ExternalToolLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalToolLauncherTests.swift; sourceTree = "<group>"; };
 		BBE71833015D389E58D69922 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		BDCFA92CC6D4F4BDC422F3E2 /* MenuBarIcon.svg */ = {isa = PBXFileReference; path = MenuBarIcon.svg; sourceTree = "<group>"; };
 		BF799E855838610F7B5E4345 /* RepositoryListViewModelNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListViewModelNavigationTests.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				CA1521E4788D6CDF1C92F4C9 /* BackgroundJobStateTests.swift */,
 				84FF3EA9723E4072334B4C6D /* BackgroundTaskQueueCallbackTests.swift */,
 				04943FBE79E108AEA932BE7A /* BackgroundTaskQueueTests.swift */,
+				B891A0806B6FDB6CF884972B /* ExternalToolLauncherTests.swift */,
 				BBE71833015D389E58D69922 /* HotkeyManagerTests.swift */,
 				881A1BB15AE24772D0F82EC4 /* HotkeyRecorderViewModelTests.swift */,
 				8D4E99B69FBE28C8558EEC50 /* ImportPRViewModelTests.swift */,
@@ -506,6 +509,7 @@
 				0DCEB362F2A309D8F5E5360D /* BackgroundJobStateTests.swift in Sources */,
 				BFEC814FF0CA3D4A3CAF604B /* BackgroundTaskQueueCallbackTests.swift in Sources */,
 				018CEB4BA33463D66FC56390 /* BackgroundTaskQueueTests.swift in Sources */,
+				1E8109BF316BBF3756D84C2D /* ExternalToolLauncherTests.swift in Sources */,
 				2E75657635769738BAE6D205 /* HotkeyManagerTests.swift in Sources */,
 				E1248E9B4281B30736BF3F42 /* HotkeyRecorderViewModelTests.swift in Sources */,
 				BF12B0124F855ED64994FC08 /* ImportPRViewModelTests.swift in Sources */,

--- a/OhMyWorktree/Services/ExternalToolLauncher.swift
+++ b/OhMyWorktree/Services/ExternalToolLauncher.swift
@@ -84,7 +84,11 @@ final class ExternalToolLauncher: Sendable {
             throw OhMyWorktreeError.externalToolNotFound(tool: "cmux")
         }
 
-        let socketPath = "/tmp/cmux.sock"
+        let socketPath = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("cmux/cmux.sock")
+            .path
 
         // If cmux is not running, launch it and wait for the socket
         if !FileManager.default.fileExists(atPath: socketPath) {

--- a/OhMyWorktree/Services/ExternalToolLauncher.swift
+++ b/OhMyWorktree/Services/ExternalToolLauncher.swift
@@ -108,12 +108,39 @@ final class ExternalToolLauncher: Sendable {
         }
 
         try cmuxSocketCommand(socketPath: socketPath) { send in
-            let result = try send("new_workspace")
-            let workspaceID = result.replacingOccurrences(of: "OK ", with: "")
-            _ = try send("select_workspace \(workspaceID)")
-            _ = try send("send cd \(path)")
-            _ = try send("send_key enter")
+            try Self.runCmuxOpenProtocol(path: path, send: send)
         }
+    }
+
+    // MARK: - cmux Protocol
+
+    /// Runs the cmux socket protocol to create a new workspace and `cd` to `path`.
+    ///
+    /// All cmux command sequencing lives here so future protocol changes have a
+    /// single point of modification.
+    ///
+    /// `send` is the per-command socket round-trip: write `<cmd>\n`, wait, read OK.
+    /// `chunkSize` splits the cd command because cmux's `send` returns OK before
+    /// finishing typing — `send_key enter` arriving mid-typing drops characters.
+    /// Keeping each chunk short lets cmux drain typing within the per-command
+    /// delay.
+    static func runCmuxOpenProtocol(
+        path: String,
+        chunkSize: Int = 40,
+        send: (String) throws -> String
+    ) throws {
+        let result = try send("new_workspace")
+        let workspaceID = result.replacingOccurrences(of: "OK ", with: "")
+        _ = try send("select_workspace \(workspaceID)")
+
+        let cdCommand = "cd \(path)"
+        var index = cdCommand.startIndex
+        while index < cdCommand.endIndex {
+            let end = cdCommand.index(index, offsetBy: chunkSize, limitedBy: cdCommand.endIndex) ?? cdCommand.endIndex
+            _ = try send("send \(cdCommand[index..<end])")
+            index = end
+        }
+        _ = try send("send_key enter")
     }
 
     // MARK: - Tool Detection

--- a/OhMyWorktreeTests/ExternalToolLauncherTests.swift
+++ b/OhMyWorktreeTests/ExternalToolLauncherTests.swift
@@ -1,0 +1,123 @@
+import Testing
+
+@testable import OhMyWorktree
+
+struct ExternalToolLauncherTests {
+
+    // MARK: - cmux Protocol
+
+    private final class SendRecorder {
+        var commands: [String] = []
+        var workspaceID = "WS-1234"
+
+        func send(_ cmd: String) throws -> String {
+            commands.append(cmd)
+            if cmd == "new_workspace" {
+                return "OK \(workspaceID)"
+            }
+            return "OK"
+        }
+    }
+
+    @Test func runCmuxOpenProtocol_emitsExpectedSequence() throws {
+        let recorder = SendRecorder()
+        try ExternalToolLauncher.runCmuxOpenProtocol(
+            path: "/short/path",
+            chunkSize: 40,
+            send: recorder.send
+        )
+
+        #expect(recorder.commands == [
+            "new_workspace",
+            "select_workspace WS-1234",
+            "send cd /short/path",
+            "send_key enter"
+        ])
+    }
+
+    @Test func runCmuxOpenProtocol_chunksLongPaths() throws {
+        let recorder = SendRecorder()
+        let path = "/Users/sapsaldog/oh-my-worktree/workspaces/translator-pro-752884/monaco-zenith"
+        try ExternalToolLauncher.runCmuxOpenProtocol(
+            path: path,
+            chunkSize: 40,
+            send: recorder.send
+        )
+
+        let sendCalls = recorder.commands.filter { $0.hasPrefix("send ") && !$0.hasPrefix("send_key") }
+        #expect(sendCalls.count > 1, "Long path should split into multiple send calls")
+
+        let typedText = sendCalls.map { String($0.dropFirst("send ".count)) }.joined()
+        #expect(typedText == "cd \(path)")
+    }
+
+    @Test func runCmuxOpenProtocol_lastCommandIsEnter() throws {
+        let recorder = SendRecorder()
+        try ExternalToolLauncher.runCmuxOpenProtocol(
+            path: "/any/path",
+            chunkSize: 40,
+            send: recorder.send
+        )
+        #expect(recorder.commands.last == "send_key enter")
+    }
+
+    @Test func runCmuxOpenProtocol_extractsWorkspaceID() throws {
+        let recorder = SendRecorder()
+        recorder.workspaceID = "ABCD-EFGH"
+        try ExternalToolLauncher.runCmuxOpenProtocol(
+            path: "/x",
+            chunkSize: 40,
+            send: recorder.send
+        )
+        #expect(recorder.commands.contains("select_workspace ABCD-EFGH"))
+    }
+
+    @Test(arguments: [10, 20, 40, 100])
+    func runCmuxOpenProtocol_eachChunkRespectsChunkSize(chunkSize: Int) throws {
+        let recorder = SendRecorder()
+        let longPath = String(repeating: "a", count: 200)
+        try ExternalToolLauncher.runCmuxOpenProtocol(
+            path: longPath,
+            chunkSize: chunkSize,
+            send: recorder.send
+        )
+
+        let sendCalls = recorder.commands.filter { $0.hasPrefix("send ") && !$0.hasPrefix("send_key") }
+        for call in sendCalls {
+            let payload = String(call.dropFirst("send ".count))
+            #expect(payload.count <= chunkSize, "Chunk '\(payload)' exceeds chunkSize \(chunkSize)")
+        }
+    }
+
+    @Test func runCmuxOpenProtocol_pathWithExactlyChunkSizeIsSingleSend() throws {
+        let recorder = SendRecorder()
+        // cd + space + path = exactly 40 chars when path is 37 chars
+        let path = String(repeating: "x", count: 37)
+        try ExternalToolLauncher.runCmuxOpenProtocol(
+            path: path,
+            chunkSize: 40,
+            send: recorder.send
+        )
+        let sendCalls = recorder.commands.filter { $0.hasPrefix("send ") && !$0.hasPrefix("send_key") }
+        #expect(sendCalls == ["send cd \(path)"])
+    }
+
+    @Test func runCmuxOpenProtocol_propagatesSendErrors() {
+        struct StubError: Error {}
+        var callCount = 0
+        let send: (String) throws -> String = { _ in
+            callCount += 1
+            if callCount == 2 { throw StubError() }
+            return "OK WS"
+        }
+
+        #expect(throws: StubError.self) {
+            try ExternalToolLauncher.runCmuxOpenProtocol(
+                path: "/p",
+                chunkSize: 40,
+                send: send
+            )
+        }
+        #expect(callCount == 2, "Should stop at the failing call")
+    }
+}


### PR DESCRIPTION
## Summary
Two cmux 0.63.2 compatibility fixes exposed in sequence — the second only became visible after the first was applied.

### Fix 1: Socket path moved
cmux moved its Unix domain socket from `/tmp/cmux.sock` to `~/Library/Application Support/cmux/cmux.sock`. The hardcoded old path caused `waitForFile: File did not appear within 5 seconds: /tmp/cmux.sock` errors when opening worktrees in cmux. Resolved via `FileManager.applicationSupportDirectory`.

### Fix 2: `send` truncation
cmux's socket `send <text>` command acks immediately, but typing happens asynchronously on a queue. Sending `send_key enter` shortly after a long `send` causes the enter to interrupt typing mid-string and drop characters from the middle — producing corrupted paths like `cd /Users/sapsaldog/oh-my-worktr/monaco-zenith` (with non-deterministic drop boundaries between runs).

Workaround: split `cd <path>` into 40-char chunks. Each chunk is short enough that cmux's typing queue drains within the per-command socket delay. Verified 8/8 reliability empirically.

The cmux protocol flow is now extracted into a static `runCmuxOpenProtocol` for a single point of modification on future protocol changes.

## Test plan
- [x] `swiftlint lint` clean
- [x] `xcodebuild ... test` — 338 tests pass (7 new)
- [x] Empirically reproduced both bugs and verified fixes via direct socket testing
- [ ] Manual: `Open in cmux` succeeds with cmux 0.63.2+
- [ ] Manual: graceful error when cmux is not running (auto-launch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)