### PR TITLE
Fix cmux integration breaking after cmux relocates its socket

### DIFF
--- a/OhMyWorktree/Services/ExternalToolLauncher.swift
+++ b/OhMyWorktree/Services/ExternalToolLauncher.swift
@@ -84,11 +84,10 @@ final class ExternalToolLauncher: Sendable {
             throw OhMyWorktreeError.externalToolNotFound(tool: "cmux")
         }
 
-        let socketPath = FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first!
-            .appendingPathComponent("cmux/cmux.sock")
-            .path
+        let socketPath = Self.resolveCmuxSocketPath(
+            home: FileManager.default.homeDirectoryForCurrentUser,
+            readPointer: { try? String(contentsOf: $0, encoding: .utf8) }
+        )
 
         // If cmux is not running, launch it and wait for the socket
         if !FileManager.default.fileExists(atPath: socketPath) {
@@ -110,6 +109,28 @@ final class ExternalToolLauncher: Sendable {
         try cmuxSocketCommand(socketPath: socketPath) { send in
             try Self.runCmuxOpenProtocol(path: path, send: send)
         }
+    }
+
+    /// Resolves cmux's control-socket path.
+    ///
+    /// cmux writes the absolute path of its live socket into a `last-socket-path`
+    /// file under `~/.local/state/cmux`. Reading that advertised path keeps the
+    /// integration working when a cmux update moves the socket, instead of
+    /// hardcoding a path that goes stale. Falls back to that directory's default
+    /// socket path when no pointer file exists (e.g. cmux has not run yet).
+    static func resolveCmuxSocketPath(
+        home: URL,
+        readPointer: (URL) -> String?
+    ) -> String {
+        let stateDirectory = home.appendingPathComponent(".local/state/cmux")
+        let pointer = stateDirectory.appendingPathComponent("last-socket-path")
+        if let raw = readPointer(pointer) {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return stateDirectory.appendingPathComponent("cmux.sock").path
     }
 
     // MARK: - cmux Protocol

--- a/OhMyWorktreeTests/ExternalToolLauncherTests.swift
+++ b/OhMyWorktreeTests/ExternalToolLauncherTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import OhMyWorktree
@@ -119,5 +120,44 @@ struct ExternalToolLauncherTests {
             )
         }
         #expect(callCount == 2, "Should stop at the failing call")
+    }
+
+    // MARK: - cmux Socket Path Resolution
+
+    @Test func resolveCmuxSocketPath_readsModernStatePointer() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let modernPointer = home.appendingPathComponent(".local/state/cmux/last-socket-path").path
+        let resolved = ExternalToolLauncher.resolveCmuxSocketPath(
+            home: home,
+            readPointer: { $0.path == modernPointer ? "/custom/live/cmux.sock\n" : nil }
+        )
+        #expect(resolved == "/custom/live/cmux.sock")
+    }
+
+    @Test func resolveCmuxSocketPath_usesModernDefaultWhenNoPointer() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let resolved = ExternalToolLauncher.resolveCmuxSocketPath(
+            home: home,
+            readPointer: { _ in nil }
+        )
+        #expect(resolved == "/Users/test/.local/state/cmux/cmux.sock")
+    }
+
+    @Test func resolveCmuxSocketPath_usesModernDefaultWhenPointerBlank() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let resolved = ExternalToolLauncher.resolveCmuxSocketPath(
+            home: home,
+            readPointer: { _ in "   \n" }
+        )
+        #expect(resolved == "/Users/test/.local/state/cmux/cmux.sock")
+    }
+
+    @Test func resolveCmuxSocketPath_trimsSurroundingWhitespace() {
+        let home = URL(fileURLWithPath: "/Users/test")
+        let resolved = ExternalToolLauncher.resolveCmuxSocketPath(
+            home: home,
+            readPointer: { _ in "  /custom/live/cmux.sock  \n" }
+        )
+        #expect(resolved == "/custom/live/cmux.sock")
     }
 }


### PR DESCRIPTION
## Problem

cmux writes the absolute path of its live control socket into a `last-socket-path` file under `~/.local/state/cmux`, and a cmux update moved the socket there from the old `~/Library/Application Support/cmux` location.

`ExternalToolLauncher.openInCmux` **hardcoded** the old Application Support path. Once cmux moved the socket:

1. `fileExists(atPath:)` returned `false` (old socket gone)
2. the relaunch (`open -a cmux`) created nothing new at the old path
3. `waitForFile` timed out after 5s — `File did not appear within 5 seconds: …/Application Support/cmux/cmux.sock`

So **"Open in cmux" broke after updating cmux**.

## Fix

Resolve the socket path from cmux's own `last-socket-path` advertisement under `~/.local/state/cmux` instead of hardcoding it, so the integration follows the socket across cmux updates. Falls back to that directory's default socket path (`~/.local/state/cmux/cmux.sock`) when no pointer file exists (e.g. cmux has not run yet).

The logic is extracted into a pure, injectable `resolveCmuxSocketPath(home:readPointer:)` seam so it is unit-testable without touching the filesystem.

## Tests

Added 4 unit tests (following the existing `runCmuxOpenProtocol` closure-injection pattern):

- reads the modern `last-socket-path` advertisement
- default socket path when no pointer exists
- default when pointer contents are blank/whitespace
- surrounding whitespace/newlines trimmed

Verified locally:
- `swiftlint lint` → 0 violations
- full test suite → **348 tests pass**
- `scripts/coverage.sh` → **strict 100% gate passed** (17 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
