### PR TITLE
Fix empty Settings sheet; remove redundant toolbar gear

### DIFF
--- a/OhMyWorktree/AppDelegate+Window.swift
+++ b/OhMyWorktree/AppDelegate+Window.swift
@@ -82,6 +82,11 @@ extension AppDelegate {
         ) {
             ContentView(repoViewModel: repoVM, worktreeViewModel: worktreeVM)
                 .environment(store)
+                // Match the SwiftUI WindowGroup's injection. ContentView reads
+                // UpdaterManager as an *optional* environment value, so omitting
+                // this silently leaves it nil and the Settings sheet (gated on
+                // `if let updaterManager`) renders an empty, collapsed card.
+                .environment(updaterManager)
                 .frame(minWidth: 860, minHeight: 520)
         }
     }

--- a/OhMyWorktree/Views/MainWindow/ToolbarControls.swift
+++ b/OhMyWorktree/Views/MainWindow/ToolbarControls.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// The window's glass top bar, rendered as the first row of the content (under
 /// the transparent titlebar via `.fullSizeContentView`), so it shows reliably:
 /// native traffic-light clearance · spring · search (230) · import · refresh ·
-/// settings · ＋(accent). The native traffic lights overlay the left clearance.
+/// ＋(accent). The native traffic lights overlay the left clearance. Settings is
+/// reached from the sidebar footer, ⌘,, and the menu bar (no toolbar duplicate).
 struct ToolbarControls: View {
     @Bindable var worktreeVM: WorktreeListViewModel
     @AppStorage("accentColorName") private var accentColorName = AccentChoice.default.rawValue
@@ -22,9 +23,6 @@ struct ToolbarControls: View {
                                help: "Import from Pull Request") { worktreeVM.isShowingImportPR = true }
             ToolbarRoundButton(systemImage: "arrow.clockwise", help: "Refresh (⌘R)",
                                spinning: worktreeVM.isLoading) { Task { await worktreeVM.loadWorktrees() } }
-            ToolbarRoundButton(systemImage: "gearshape", help: "Settings (⌘,)") {
-                worktreeVM.isShowingSettings = true
-            }
             ToolbarRoundButton(systemImage: "plus", help: "New Worktree (⌘N)", filled: true) {
                 worktreeVM.isShowingCreateSheet = true
             }


### PR DESCRIPTION
## Problem

Opening **Settings** showed an empty, collapsed white card instead of the settings UI.

For this menu-bar (`.accessory`) app, the main window users actually interact with is the one `AppDelegate` creates (opened via the status item, global hotkey, or dock reopen) — **not** the SwiftUI `WindowGroup`.

## Root cause

`ContentView` reads `UpdaterManager` as an **optional** `@Environment` value:

```swift
@Environment(UpdaterManager.self) private var updaterManager: UpdaterManager?
...
private var settingsSheet: some View {
    if let updaterManager { SettingsSheetContent(updaterManager: updaterManager, store: shortcutStore) }
}
```

The SwiftUI `WindowGroup` injects both `.environment(shortcutStore)` **and** `.environment(updaterManager)`, but `AppDelegate.showOrCreateMainWindow()` hosted `ContentView` with only `.environment(store)`. The Tahoe redesign (#37) added the `updaterManager` injection to the `WindowGroup` but never to the parallel AppKit window, so the two `ContentView` hosts drifted.

Result: in the AppKit window `updaterManager` silently resolved to `nil`, the sheet body produced nothing, and SwiftUI collapsed the empty `.sheet` to the small white card.

## Changes

- **Fix:** inject `.environment(updaterManager)` into the AppKit main window so it matches the `WindowGroup`. This also restores the sidebar **"Check for Updates"** action (which was silently a no-op in that window for the same reason).
- **Cleanup:** remove the toolbar gear button — it duplicated the sidebar **"Settings"** entry. Settings remains reachable from the sidebar footer, ⌘,, and the menu bar.

## Testing

- `swiftlint lint` — clean
- `xcodebuild ... -scheme OhMyWorktreeTests test` — **405 tests pass**

> Note: `Views/**` and `AppDelegate+*.swift` are coverage-excluded AppKit/SwiftUI seams, and SwiftUI `@Environment`/`.sheet` contents aren't unit-testable here — this class of bug is only observable by running the app from the menu bar, which is why the compiler and tests didn't catch the missing injection.

## Follow-up (not in this PR)

The redesign left the old AppKit settings path as dead code (`showOrCreateSettingsWindow` + the old `SettingsView` and its child views), superseded by the `SettingsSheetContent` sheet. Worth removing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)