### PR TITLE
Add "Show icon in Dock" setting

### DIFF
--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -51,7 +51,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // item call setupStatusItem() directly, so skip all GUI launch setup here.
         guard !Self.isRunningTests else { return }
 
-        NSApp.setActivationPolicy(.accessory)
+        // No windows exist at launch, so the Dock icon shows only if the user
+        // pinned it on via "Show icon in Dock"; otherwise stay menu-bar-only.
+        NSApp.setActivationPolicy(
+            DockPolicy.activationPolicy(
+                showInDock: UserDefaults.standard.bool(forKey: DockPolicy.defaultsKey),
+                hasAppWindows: false
+            )
+        )
         NSApp.appearance = AppearanceMode.named(
             UserDefaults.standard.string(forKey: "appearanceMode")
         ).nsAppearance

--- a/OhMyWorktree/Services/DockPolicy.swift
+++ b/OhMyWorktree/Services/DockPolicy.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+/// Decides the app's Dock visibility (its activation policy) from the two inputs
+/// that affect it: whether the user pinned the Dock icon on, and whether a real
+/// app window is currently open.
+///
+/// The app is a menu-bar accessory by default. It must become `.regular` whenever
+/// a window is open (so Cmd+Tab and Cmd+` work) *and* whenever the user has opted
+/// to always show the Dock icon. Otherwise it stays `.accessory` (no Dock icon).
+enum DockPolicy {
+
+    /// `UserDefaults` / `@AppStorage` key backing the "Show icon in Dock" toggle.
+    static let defaultsKey = "showInDock"
+
+    /// Resolves the activation policy the app should currently use.
+    ///
+    /// - Parameters:
+    ///   - showInDock: the user's "Show icon in Dock" preference.
+    ///   - hasAppWindows: whether a real app window is visible or miniaturized.
+    /// - Returns: `.regular` when the Dock icon should show, otherwise `.accessory`.
+    static func activationPolicy(
+        showInDock: Bool,
+        hasAppWindows: Bool
+    ) -> NSApplication.ActivationPolicy {
+        (showInDock || hasAppWindows) ? .regular : .accessory
+    }
+}

--- a/OhMyWorktree/Services/WindowObserver.swift
+++ b/OhMyWorktree/Services/WindowObserver.swift
@@ -3,9 +3,10 @@ import AppKit
 /// Observes window lifecycle events and dynamically toggles the app's activation policy
 /// between `.accessory` (menu-bar-only) and `.regular` (Dock + Cmd+Tab).
 ///
-/// When at least one app window is visible or miniaturized, the app switches to `.regular`
-/// so that Cmd+` and Cmd+Tab work. When all windows are closed, it switches back to `.accessory`
-/// so the Dock icon disappears.
+/// The app switches to `.regular` whenever an app window is visible or miniaturized
+/// (so Cmd+` and Cmd+Tab work) *or* whenever the user enabled "Show icon in Dock".
+/// When neither holds, it returns to `.accessory` so the Dock icon disappears.
+/// The decision itself lives in `DockPolicy`.
 @MainActor
 final class WindowObserver {
 
@@ -41,6 +42,12 @@ final class WindowObserver {
             name: NSWindow.didDeminiaturizeNotification,
             object: nil
         )
+        center.addObserver(
+            self,
+            selector: #selector(showInDockSettingChanged(_:)),
+            name: .showInDockSettingChanged,
+            object: nil
+        )
     }
 
     // MARK: - Notification Handlers
@@ -68,6 +75,10 @@ final class WindowObserver {
         updateActivationPolicy()
     }
 
+    @objc private func showInDockSettingChanged(_ notification: Notification) {
+        updateActivationPolicy()
+    }
+
     // MARK: - Policy Management
 
     private func updateActivationPolicy() {
@@ -75,7 +86,8 @@ final class WindowObserver {
             isAppWindow(window) && (window.isVisible || window.isMiniaturized)
         }
 
-        let desiredPolicy: NSApplication.ActivationPolicy = hasAppWindows ? .regular : .accessory
+        let showInDock = UserDefaults.standard.bool(forKey: DockPolicy.defaultsKey)
+        let desiredPolicy = DockPolicy.activationPolicy(showInDock: showInDock, hasAppWindows: hasAppWindows)
         let currentPolicy = NSApp.activationPolicy()
 
         guard desiredPolicy != currentPolicy else { return }
@@ -119,4 +131,10 @@ final class WindowObserver {
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
+}
+
+extension Notification.Name {
+    /// Posted when the user toggles "Show icon in Dock". `WindowObserver`
+    /// re-evaluates the activation policy in response.
+    static let showInDockSettingChanged = Notification.Name("com.ohmyworktree.showInDockSettingChanged")
 }

--- a/OhMyWorktree/Views/SettingsSheetContent.swift
+++ b/OhMyWorktree/Views/SettingsSheetContent.swift
@@ -133,7 +133,7 @@ func settingsHairline() -> some View {
 
 private struct GeneralTab: View {
     @AppStorage("copyEnvFilesEnabled") private var copyEnvFilesEnabled = true
-    @AppStorage("showInMenuBar") private var showInMenuBar = true
+    @AppStorage(DockPolicy.defaultsKey) private var showInDock = false
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
     var body: some View {
@@ -149,9 +149,12 @@ private struct GeneralTab: View {
                     .onChange(of: launchAtLogin) { _, newValue in setLaunchAtLogin(newValue) }
             }
             settingsHairline()
-            SettingsRow(icon: "line.3.horizontal", title: "Show in menu bar",
-                        subtitle: "Keep running in the menu bar without a Dock icon") {
-                Toggle("", isOn: $showInMenuBar).labelsHidden().toggleStyle(.switch)
+            SettingsRow(icon: "dock.rectangle", title: "Show icon in Dock",
+                        subtitle: "Keep the app icon in the Dock even when no window is open") {
+                Toggle("", isOn: $showInDock).labelsHidden().toggleStyle(.switch)
+                    .onChange(of: showInDock) { _, _ in
+                        NotificationCenter.default.post(name: .showInDockSettingChanged, object: nil)
+                    }
             }
         }
         .onAppear { launchAtLogin = SMAppService.mainApp.status == .enabled }

--- a/OhMyWorktreeTests/DockPolicyTests.swift
+++ b/OhMyWorktreeTests/DockPolicyTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct DockPolicyTests {
+
+    @Test func defaultsKeyIsStable() {
+        #expect(DockPolicy.defaultsKey == "showInDock")
+    }
+
+    @Test func accessoryWhenIdleAndNotPinned() {
+        #expect(DockPolicy.activationPolicy(showInDock: false, hasAppWindows: false) == .accessory)
+    }
+
+    @Test func regularWhenPinnedEvenWithoutWindows() {
+        #expect(DockPolicy.activationPolicy(showInDock: true, hasAppWindows: false) == .regular)
+    }
+
+    @Test func regularWhenWindowOpenEvenIfNotPinned() {
+        #expect(DockPolicy.activationPolicy(showInDock: false, hasAppWindows: true) == .regular)
+    }
+
+    @Test func regularWhenPinnedAndWindowOpen() {
+        #expect(DockPolicy.activationPolicy(showInDock: true, hasAppWindows: true) == .regular)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Settings → General** toggle, **"Show icon in Dock"**, that lets users keep the app icon in the Dock even when no window is open.

| Toggle | Behavior |
|--------|----------|
| **On** | Dock icon is always shown (app stays `.regular`). |
| **Off** (default) | Current behavior preserved: menu-bar-only while idle, switching to a Dock icon only while a window is open — so Cmd+Tab / Cmd+`` ` `` keep working. |

The default is **Off**, so existing users see no change after updating.

## Implementation

- **New pure helper `DockPolicy`** decides the activation policy from two inputs — `showInDock` (the preference) and `hasAppWindows` — returning `.regular` when either is true, else `.accessory`. It owns the `UserDefaults`/`@AppStorage` key (`"showInDock"`) as the single source of truth.
- **`WindowObserver`** now reads the preference and uses `DockPolicy`, and re-evaluates the policy when the toggle changes (via a new `.showInDockSettingChanged` notification) so the Dock icon stays pinned after the last window closes.
- **`AppDelegate`** applies the saved preference at launch instead of hardcoding `.accessory`.
- **Removed** the adjacent **"Show in menu bar"** toggle, which was wired to nothing (dead `@AppStorage`).

The `NSApp`-touching glue lives in already coverage-excluded files (`WindowObserver`, `AppDelegate`, view bodies); the decision logic is isolated in `DockPolicy` so it is fully unit-tested.

## Testing

- New `DockPolicyTests` — 5 cases covering all `showInDock` × `hasAppWindows` combinations.
- `swiftlint lint` — clean.
- Full suite: **410 tests passed**.
- `scripts/coverage.sh` — **strict 100% gate passed (22 files)**; `DockPolicy.swift` included.

> Note: there is a separate, orphaned `SettingsView`/`GeneralSettingsView` settings window (`showOrCreateSettingsWindow()` has no remaining callers). It is out of scope here and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)