### PR TITLE
Match sheet toggles to the design prototype's mac-switch

### DIFF
--- a/OhMyWorktree/Views/Components/OMWComponents.swift
+++ b/OhMyWorktree/Views/Components/OMWComponents.swift
@@ -226,3 +226,53 @@ struct CopiedFileChip: View {
         .background(OMWColor.fillTertiary, in: Capsule())
     }
 }
+
+// MARK: - Switch toggle
+
+/// The prototype's `.mac-switch` (components.css): a 38×22 pill that fills with the
+/// accent when on, carrying an 18×18 white knob that slides 16px. Use via
+/// `.toggleStyle(.omwSwitch)` so glass-sheet toggles match the Tahoe mockup exactly
+/// instead of the native `.switch`.
+struct OMWSwitchToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        SwitchBody(configuration: configuration)
+    }
+
+    // A nested View so `@Environment(\.omwAccent)` is actually injected — environment
+    // values are not reliably populated on a bare ToggleStyle struct.
+    private struct SwitchBody: View {
+        let configuration: ToggleStyleConfiguration
+        @Environment(\.omwAccent) private var accent
+
+        var body: some View {
+            Button { configuration.isOn.toggle() } label: { track }
+                .buttonStyle(.plain)
+                .accessibilityRepresentation {
+                    Toggle(isOn: configuration.$isOn) { configuration.label }
+                }
+        }
+
+        private var track: some View {
+            Capsule()
+                .fill(OMWColor.fillPrimary)
+                .frame(width: 38, height: 22)
+                .overlay { Capsule().fill(accent).opacity(configuration.isOn ? 1 : 0) }
+                .overlay(alignment: .leading) { knob }
+                .animation(.timingCurve(0.32, 0.72, 0, 1, duration: 0.22), value: configuration.isOn)
+        }
+
+        private var knob: some View {
+            Circle()
+                .fill(.white)
+                .frame(width: 18, height: 18)
+                .overlay { Circle().strokeBorder(.black.opacity(0.04), lineWidth: 0.5) }
+                .shadow(color: .black.opacity(0.25), radius: 1, y: 1)
+                .offset(x: configuration.isOn ? 18 : 2)
+        }
+    }
+}
+
+extension ToggleStyle where Self == OMWSwitchToggleStyle {
+    /// The Tahoe `.mac-switch` pill — see ``OMWSwitchToggleStyle``.
+    static var omwSwitch: OMWSwitchToggleStyle { OMWSwitchToggleStyle() }
+}

--- a/OhMyWorktree/Views/SettingsSheetContent.swift
+++ b/OhMyWorktree/Views/SettingsSheetContent.swift
@@ -140,18 +140,18 @@ private struct GeneralTab: View {
         SettingsCard {
             SettingsRow(icon: "doc.on.doc", title: "Copy files to new worktrees",
                         subtitle: "Use .worktreeinclude patterns when creating worktrees") {
-                Toggle("", isOn: $copyEnvFilesEnabled).labelsHidden().toggleStyle(.switch)
+                Toggle("Copy files to new worktrees", isOn: $copyEnvFilesEnabled).toggleStyle(.omwSwitch)
             }
             settingsHairline()
             SettingsRow(icon: "power", title: "Launch at Login",
                         subtitle: "Start Oh My Worktree automatically when you log in") {
-                Toggle("", isOn: $launchAtLogin).labelsHidden().toggleStyle(.switch)
+                Toggle("Launch at Login", isOn: $launchAtLogin).toggleStyle(.omwSwitch)
                     .onChange(of: launchAtLogin) { _, newValue in setLaunchAtLogin(newValue) }
             }
             settingsHairline()
             SettingsRow(icon: "dock.rectangle", title: "Show icon in Dock",
                         subtitle: "Keep the app icon in the Dock even when no window is open") {
-                Toggle("", isOn: $showInDock).labelsHidden().toggleStyle(.switch)
+                Toggle("Show icon in Dock", isOn: $showInDock).toggleStyle(.omwSwitch)
                     .onChange(of: showInDock) { _, _ in
                         NotificationCenter.default.post(name: .showInDockSettingChanged, object: nil)
                     }
@@ -273,7 +273,7 @@ private struct ShortcutsTab: View {
             SettingsCard {
                 SettingsRow(icon: "globe", title: "Enable global hotkey",
                             subtitle: "Toggle the menu bar popup from anywhere") {
-                    Toggle("", isOn: $globalHotkeyEnabled).labelsHidden().toggleStyle(.switch)
+                    Toggle("Enable global hotkey", isOn: $globalHotkeyEnabled).toggleStyle(.omwSwitch)
                         .onChange(of: globalHotkeyEnabled) { _, on in
                             on ? KeyboardShortcuts.enable(.toggleMenuBarPopup) : KeyboardShortcuts.disable(.toggleMenuBarPopup)
                         }
@@ -317,12 +317,11 @@ private struct UpdatesTab: View {
             SettingsCard {
                 SettingsRow(icon: "arrow.triangle.2.circlepath", title: "Automatically check for updates",
                             subtitle: "Powered by Sparkle") {
-                    Toggle("", isOn: Binding(
+                    Toggle("Automatically check for updates", isOn: Binding(
                         get: { updaterManager.automaticallyChecksForUpdates },
                         set: { updaterManager.automaticallyChecksForUpdates = $0 }
                     ))
-                    .labelsHidden()
-                    .toggleStyle(.switch)
+                    .toggleStyle(.omwSwitch)
                 }
             }
             VStack(spacing: 6) {

--- a/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
+++ b/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
@@ -64,13 +64,15 @@ struct CreateWorktreeSheet: View {
                 .pickerStyle(.menu)
             }
 
-            Toggle(isOn: $copyFiles) {
+            HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Copy files to new worktree").font(.system(size: 13, weight: .medium))
                     Text("Apply .worktreeinclude patterns (.env*, local configs)")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
+                Spacer(minLength: 10)
+                Toggle("Copy files to new worktree", isOn: $copyFiles).toggleStyle(.omwSwitch)
             }
         }
         .padding(20)


### PR DESCRIPTION
## Summary
The glass **settings** and **create-worktree** sheets used the native `.switch` toggle, which didn't match the Tahoe design prototype's custom `.mac-switch` (`components.css`). This adds a reusable `OMWSwitchToggleStyle` that reproduces the prototype spec exactly and applies it to every glass-sheet toggle.

## Prototype spec → implementation (`.mac-switch`)
| Property | Prototype | Implementation |
|---|---|---|
| Track | `38×22` pill | `Capsule().frame(width: 38, height: 22)` |
| Off / On color | `--fill-primary` / `--accent` | `OMWColor.fillPrimary` / `\.omwAccent` |
| Knob | `18×18` `#fff`, `2px` inset | `Circle()` 18×18, offset `2 → 18` (16px travel) |
| Knob shadow | `0 1px 2px rgba(0,0,0,.25)` + `0 0 0 .5px rgba(0,0,0,.04)` | `.shadow(…0.25, r:1, y:1)` + 0.5pt 4% border |
| Animation | `.22s cubic-bezier(.32,.72,0,1)` | `.timingCurve(0.32, 0.72, 0, 1, duration: 0.22)` |

## Changes
- **Add** `OMWSwitchToggleStyle` in `OMWComponents.swift`, used via `.toggleStyle(.omwSwitch)`. Reads the user's accent through `\.omwAccent`; preserves keyboard activation and VoiceOver via `accessibilityRepresentation`.
- **SettingsSheetContent** — 5 toggles converted (General: Copy files, Launch at Login, Show icon in Dock; Shortcuts: enable global hotkey; Updates: auto-check).
- **CreateWorktreeSheet** — unify the *Copy files* toggle to the same style.

## Testing
- `swiftlint lint` — clean
- `xcodebuild … OhMyWorktreeTests test` — **410 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
