### PR TITLE
Tint Settings sheet toggles with the chosen accent

### DIFF
--- a/OhMyWorktree/Views/SettingsSheetContent.swift
+++ b/OhMyWorktree/Views/SettingsSheetContent.swift
@@ -54,6 +54,7 @@ struct SettingsSheetContent: View {
         .frame(width: 500, height: 540)
         .background(.regularMaterial)
         .tint(accent)
+        .environment(\.omwAccent, accent)
     }
 
     @ViewBuilder private var tabContent: some View {


### PR DESCRIPTION
The `.omwSwitch` toggle style added in #42 colors its track from `\.omwAccent`, **not** `.tint`. `SettingsSheetContent` applied `.tint(accent)` but never injected `.environment(\.omwAccent, accent)`, so its five toggles fell back to the `\.omwAccent` `@Entry` default (`AccentChoice.default.color`) regardless of the users chosen accent — the toggle tracks did not match the rest of the accent-tinted sheet.

## Fix
Inject `.environment(\.omwAccent, accent)` next to `.tint(accent)` on the sheet, mirroring `ContentView`, which already pairs both.

```swift
.frame(width: 500, height: 540)
.background(.regularMaterial)
.tint(accent)
.environment(\.omwAccent, accent)   // added
```

`CreateWorktreeSheet` was unaffected: it reads `\.omwAccent` from the environment as a pure consumer, so its toggle already inherits the correct value.

## Testing
- `swiftlint lint` — clean
- `scripts/coverage.sh` — 410 tests pass; strict 100% coverage gate passes (22 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)