### PR TITLE
Add repository empty state, context menu, and drag-to-reorder

### DIFF
--- a/OhMyWorktree/Services/RepositoryStore.swift
+++ b/OhMyWorktree/Services/RepositoryStore.swift
@@ -161,6 +161,19 @@ actor RepositoryStore {
         saveToDisk()
     }
 
+    /// Persist a new ordering for the repository list. `orderedIDs` must be a
+    /// permutation of the current repository IDs (same set, no duplicates);
+    /// anything else is ignored so a stale or partial drag can never drop a repo.
+    func reorderRepositories(orderedIDs: [UUID]) {
+        let byID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
+        let reordered = orderedIDs.compactMap { byID[$0] }
+        guard reordered.count == repositories.count,
+              Set(orderedIDs) == Set(byID.keys) else { return }
+        repositories = reordered
+        dirtyRepos = true
+        saveToDisk()
+    }
+
     // MARK: - Worktree Metadata
 
     func getWorktreeMetadata(repositoryID: UUID) -> [WorktreeMetadata] {

--- a/OhMyWorktree/ViewModels/RepositoryListViewModel.swift
+++ b/OhMyWorktree/ViewModels/RepositoryListViewModel.swift
@@ -132,6 +132,21 @@ final class RepositoryListViewModel {
         await selectRepository(repositories[prevIndex])
     }
 
+    // MARK: - Reorder
+
+    /// Move the repository identified by `fromID` to the slot currently held by
+    /// `toID`, mirroring the prototype's drag-to-reorder, and persist the order.
+    func moveRepository(_ fromID: UUID, to toID: UUID) async {
+        guard fromID != toID else { return }
+        var arr = repositories
+        guard let from = arr.firstIndex(where: { $0.id == fromID }),
+              let to = arr.firstIndex(where: { $0.id == toID }) else { return }
+        let moved = arr.remove(at: from)
+        arr.insert(moved, at: to)
+        repositories = arr
+        await store.reorderRepositories(orderedIDs: arr.map(\.id))
+    }
+
     // MARK: - Error Handling
 
     func clearError() {

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @AppStorage("accentColorName") private var accentColorName = AccentChoice.default.rawValue
     @AppStorage("sidebarWidth") private var sidebarWidth: Double = 220
     @AppStorage("detailWidth") private var detailWidth: Double = 360
+    @State private var repoPendingRemoval: Repository?
 
     private var accent: Color { AccentChoice.named(accentColorName).color }
 
@@ -16,38 +17,14 @@ struct ContentView: View {
         ZStack {
             VStack(spacing: 0) {
                 ToolbarControls(worktreeVM: worktreeViewModel)
-
-                HStack(spacing: 0) {
-                    RepositorySidebar(
-                        repoVM: repoViewModel,
-                        width: CGFloat(sidebarWidth),
-                        selectedWorktreeCount: worktreeViewModel.worktrees.count,
-                        onSelect: { repo in Task { await repoViewModel.selectRepository(repo) } },
-                        onAddRepo: { repoViewModel.showingFileDialog = true },
-                        onSettings: { worktreeViewModel.isShowingSettings = true },
-                        onCheckUpdates: { updaterManager?.checkForUpdates() }
-                    )
-                    ColumnResizer(width: $sidebarWidth, range: 180...320)
-                    WorktreeListColumn(worktreeVM: worktreeViewModel)
-                    ColumnResizer(width: $detailWidth, range: 300...520, inverted: true)
-                    DetailPaneView(
-                        worktree: selectedWorktree,
-                        isRoot: isRootSelected,
-                        pullRequest: selectedPullRequest,
-                        detail: worktreeViewModel.selectedWorktreeDetail,
-                        tools: detailTools,
-                        width: CGFloat(detailWidth),
-                        onOpenPR: {
-                            if let wt = selectedWorktree { worktreeViewModel.openPullRequest(for: wt) }
-                        }
+                workspaceRow
+                if !repoViewModel.repositories.isEmpty {
+                    WindowStatusBar(
+                        worktreeViewModel: worktreeViewModel,
+                        pathText: statusBarPath,
+                        repositoryID: repoViewModel.selectedRepository?.id
                     )
                 }
-
-                WindowStatusBar(
-                    worktreeViewModel: worktreeViewModel,
-                    pathText: statusBarPath,
-                    repositoryID: repoViewModel.selectedRepository?.id
-                )
             }
             shortcutButtons
         }
@@ -106,6 +83,23 @@ struct ContentView: View {
         } message: {
             Text(repoViewModel.errorMessage ?? worktreeViewModel.errorMessage ?? "")
         }
+        .alert(
+            repoPendingRemoval.map { "Remove \u{201C}\($0.name)\u{201D} from Oh My Worktree?" } ?? "",
+            isPresented: .init(
+                get: { repoPendingRemoval != nil },
+                set: { if !$0 { repoPendingRemoval = nil } }
+            ),
+            presenting: repoPendingRemoval
+        ) { repo in
+            Button("Remove Repository", role: .destructive) {
+                Task { await repoViewModel.removeRepository(repo) }
+                repoPendingRemoval = nil
+            }
+            Button("Cancel", role: .cancel) { repoPendingRemoval = nil }
+        } message: { _ in
+            Text("This removes it from your repository list only. "
+                + "The repository and its worktrees stay on disk — nothing is deleted.")
+        }
         .task {
             if repoViewModel.repositories.isEmpty {
                 await repoViewModel.loadRepositories()
@@ -129,6 +123,53 @@ struct ContentView: View {
         .task(id: selectedWorktree?.id) {
             await worktreeViewModel.loadDetail(for: selectedWorktree)
         }
+    }
+
+    // MARK: - Workspace layout
+
+    /// Sidebar + (empty state | worktree list + detail). Extracted from `body`
+    /// to keep each SwiftUI expression small enough for the type-checker.
+    private var workspaceRow: some View {
+        HStack(spacing: 0) {
+            RepositorySidebar(
+                repoVM: repoViewModel,
+                width: CGFloat(sidebarWidth),
+                selectedWorktreeCount: worktreeViewModel.worktrees.count,
+                onSelect: { repo in Task { await repoViewModel.selectRepository(repo) } },
+                onAddRepo: { repoViewModel.showingFileDialog = true },
+                onSettings: { worktreeViewModel.isShowingSettings = true },
+                onCheckUpdates: { updaterManager?.checkForUpdates() },
+                onRequestRemove: { repoPendingRemoval = $0 }
+            )
+            ColumnResizer(width: $sidebarWidth, range: 180...320)
+            if repoViewModel.repositories.isEmpty {
+                RepositoryEmptyState(
+                    onAdd: { repoViewModel.showingFileDialog = true },
+                    onDropFolder: { url in
+                        Task { await repoViewModel.addRepository(at: url.path(percentEncoded: false)) }
+                    }
+                )
+            } else {
+                worktreeColumns
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var worktreeColumns: some View {
+        WorktreeListColumn(worktreeVM: worktreeViewModel)
+        ColumnResizer(width: $detailWidth, range: 300...520, inverted: true)
+        DetailPaneView(
+            worktree: selectedWorktree,
+            isRoot: isRootSelected,
+            pullRequest: selectedPullRequest,
+            detail: worktreeViewModel.selectedWorktreeDetail,
+            tools: detailTools,
+            width: CGFloat(detailWidth),
+            onOpenPR: {
+                if let wt = selectedWorktree { worktreeViewModel.openPullRequest(for: wt) }
+            }
+        )
     }
 
     // MARK: - Derived state

--- a/OhMyWorktree/Views/MainWindow/RepositoryEmptyState.swift
+++ b/OhMyWorktree/Views/MainWindow/RepositoryEmptyState.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Shown in place of the worktree list + detail when no repositories are tracked.
+/// Ports the prototype's `.omw-empty` block: art tile, title, subtitle, a primary
+/// pill "Add Repository…" button, and a drop-a-`.git`-folder hint (which is wired
+/// to actually add the dropped repository).
+struct RepositoryEmptyState: View {
+    var onAdd: () -> Void
+    var onDropFolder: (URL) -> Void
+
+    @Environment(\.omwAccent) private var accent
+
+    var body: some View {
+        VStack(spacing: 0) {
+            art
+            Text("No Repositories")
+                .font(.system(size: 19, weight: .bold))
+                .tracking(-0.19)
+                .foregroundStyle(OMWColor.labelPrimary)
+                .padding(.bottom, 7)
+            Text("Add a Git repository and Oh My Worktree will track its branches and worktrees here.")
+                .font(.system(size: 13))
+                .foregroundStyle(OMWColor.labelSecondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(6)
+                .frame(maxWidth: 320)
+                .padding(.bottom, 22)
+            addButton
+            hint
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(OMWColor.bgWindow)
+        .dropDestination(for: URL.self) { urls, _ in
+            guard let url = urls.first else { return false }
+            onDropFolder(url)
+            return true
+        }
+    }
+
+    /// 84×84 rounded tile with the folder-git glyph (CSS `.empty-art`).
+    private var art: some View {
+        Image("FolderGit2")
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 40, height: 40)
+            .foregroundStyle(OMWColor.labelTertiary)
+            .frame(width: 84, height: 84)
+            .background(OMWColor.fillQuaternary, in: RoundedRectangle(cornerRadius: OMWRadius.xxl))
+            .overlay(
+                RoundedRectangle(cornerRadius: OMWRadius.xxl)
+                    .strokeBorder(OMWColor.separator, lineWidth: 0.5)
+            )
+            .padding(.bottom, 18)
+    }
+
+    private var addButton: some View {
+        Button(action: onAdd) {
+            HStack(spacing: 7) {
+                Image(systemName: "folder.badge.plus").font(.system(size: 15))
+                Text("Add Repository…").font(.system(size: 13, weight: .medium))
+            }
+            .foregroundStyle(OMWColor.onAccent)
+            .padding(.horizontal, 16)
+            .frame(height: 32)
+            .background(accent, in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var hint: some View {
+        (
+            Text("or drop a ")
+                + Text(".git").font(.omwMono(11.5, weight: .semibold))
+                + Text(" folder onto the window")
+        )
+        .font(.system(size: 11.5))
+        .foregroundStyle(OMWColor.labelTertiary)
+        .padding(.top, 14)
+    }
+}

--- a/OhMyWorktree/Views/MainWindow/RepositorySidebar.swift
+++ b/OhMyWorktree/Views/MainWindow/RepositorySidebar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Left column (220): REPOSITORIES header + repo rows + footer
@@ -10,8 +11,11 @@ struct RepositorySidebar: View {
     var onAddRepo: () -> Void
     var onSettings: () -> Void
     var onCheckUpdates: () -> Void
+    var onRequestRemove: (Repository) -> Void
 
     @Environment(\.omwAccent) private var accent
+    /// Row currently hovered as a drop target during a drag-to-reorder.
+    @State private var dropTargetRepoID: UUID?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -56,34 +60,83 @@ struct RepositorySidebar: View {
 
     private func row(_ repo: Repository) -> some View {
         let isSelected = repoVM.selectedRepository?.id == repo.id
-        return Button {
-            onSelect(repo)
-        } label: {
-            HStack(spacing: 9) {
-                Image("FolderGit2")
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 16, height: 16)
-                    .foregroundStyle(isSelected ? OMWColor.onAccent : accent)
-                Text(repo.name)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(isSelected ? OMWColor.onAccent : OMWColor.labelPrimary)
-                    .lineLimit(1)
-                Spacer(minLength: 4)
-                if isSelected {
-                    Text("\(selectedWorktreeCount)")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(OMWColor.onAccent.opacity(0.75))
-                }
-            }
-            .padding(.horizontal, 10)
-            .frame(height: 32)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isSelected ? accent : Color.clear, in: RoundedRectangle(cornerRadius: OMWRadius.md))
-            .contentShape(Rectangle())
+        return Button { onSelect(repo) } label: {
+            rowLabel(repo, isSelected: isSelected)
         }
         .buttonStyle(.plain)
+        .overlay(alignment: .top) { dropIndicator(for: repo) }
+        .draggable(repo.id.uuidString)
+        .dropDestination(for: String.self) { items, _ in
+            handleDrop(items, onto: repo)
+        } isTargeted: { targeted in
+            setDropTarget(repo.id, targeted: targeted)
+        }
+        .contextMenu { repoContextMenu(repo) }
+    }
+
+    private func rowLabel(_ repo: Repository, isSelected: Bool) -> some View {
+        HStack(spacing: 9) {
+            Image("FolderGit2")
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 16, height: 16)
+                .foregroundStyle(isSelected ? OMWColor.onAccent : accent)
+            Text(repo.name)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(isSelected ? OMWColor.onAccent : OMWColor.labelPrimary)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            if isSelected {
+                Text("\(selectedWorktreeCount)")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(OMWColor.onAccent.opacity(0.75))
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 32)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isSelected ? accent : Color.clear, in: RoundedRectangle(cornerRadius: OMWRadius.md))
+        .contentShape(Rectangle())
+    }
+
+    /// Accent insertion line on the hovered drop target (CSS `.sb-row.drop-target`).
+    @ViewBuilder
+    private func dropIndicator(for repo: Repository) -> some View {
+        if dropTargetRepoID == repo.id {
+            Capsule().fill(accent).frame(height: 1.5).padding(.horizontal, 2)
+        }
+    }
+
+    private func handleDrop(_ items: [String], onto repo: Repository) -> Bool {
+        dropTargetRepoID = nil
+        guard let first = items.first, let fromID = UUID(uuidString: first) else { return false }
+        Task { await repoVM.moveRepository(fromID, to: repo.id) }
+        return true
+    }
+
+    private func setDropTarget(_ id: UUID, targeted: Bool) {
+        if targeted {
+            dropTargetRepoID = id
+        } else if dropTargetRepoID == id {
+            dropTargetRepoID = nil
+        }
+    }
+
+    @ViewBuilder
+    private func repoContextMenu(_ repo: Repository) -> some View {
+        Button("Show in Finder") {
+            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: repo.path)
+        }
+        Button("Copy Path") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(repo.path, forType: .string)
+        }
+        .keyboardShortcut("c", modifiers: .command)
+        Divider()
+        Button("Remove Repository…", role: .destructive) {
+            onRequestRemove(repo)
+        }
     }
 
     private var footer: some View {

--- a/OhMyWorktree/Views/Theme/OMWTheme.swift
+++ b/OhMyWorktree/Views/Theme/OMWTheme.swift
@@ -33,6 +33,7 @@ enum OMWColor {
     static let fillPrimary = dynamic(light: (0, 0, 0, 0.1), dark: (255, 255, 255, 0.1))
     static let fillSecondary = dynamic(light: (0, 0, 0, 0.08), dark: (255, 255, 255, 0.08))
     static let fillTertiary = dynamic(light: (0, 0, 0, 0.05), dark: (255, 255, 255, 0.05))
+    static let fillQuaternary = dynamic(light: (0, 0, 0, 0.03), dark: (255, 255, 255, 0.03))
     static let separator = dynamic(light: (0, 0, 0, 0.12), dark: (255, 255, 255, 0.14))
 
     // MARK: Backgrounds

--- a/OhMyWorktreeTests/RepositoryListViewModelTests.swift
+++ b/OhMyWorktreeTests/RepositoryListViewModelTests.swift
@@ -341,4 +341,69 @@ struct RepositoryListViewModelTests {
 
         #expect(sut.errorMessage == nil)
     }
+
+    // MARK: - moveRepository (reordering)
+
+    @Test func moveRepository_reordersToTargetPosition() async {
+        let a = Repository(name: "A", path: "/tmp/mv-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/mv-b-\(UUID().uuidString)")
+        let c = Repository(name: "C", path: "/tmp/mv-c-\(UUID().uuidString)")
+        sut.repositories = [a, b, c]
+
+        // Move C onto A's slot → [C, A, B] (matches the prototype's splice semantics).
+        await sut.moveRepository(c.id, to: a.id)
+
+        #expect(sut.repositories.map(\.id) == [c.id, a.id, b.id])
+    }
+
+    @Test func moveRepository_sameID_isNoOp() async {
+        let a = Repository(name: "A", path: "/tmp/mv-same-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/mv-same-b-\(UUID().uuidString)")
+        sut.repositories = [a, b]
+
+        await sut.moveRepository(a.id, to: a.id)
+
+        #expect(sut.repositories.map(\.id) == [a.id, b.id])
+    }
+
+    @Test func moveRepository_unknownSourceID_isNoOp() async {
+        let a = Repository(name: "A", path: "/tmp/mv-unk-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/mv-unk-b-\(UUID().uuidString)")
+        sut.repositories = [a, b]
+
+        await sut.moveRepository(UUID(), to: a.id)
+
+        #expect(sut.repositories.map(\.id) == [a.id, b.id])
+    }
+
+    @Test func moveRepository_unknownTargetID_isNoOp() async {
+        let a = Repository(name: "A", path: "/tmp/mv-unt-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/mv-unt-b-\(UUID().uuidString)")
+        sut.repositories = [a, b]
+
+        await sut.moveRepository(a.id, to: UUID())
+
+        #expect(sut.repositories.map(\.id) == [a.id, b.id])
+    }
+
+    @Test func moveRepository_persistsNewOrderToStore() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("repo-move-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = RepositoryStore(storageDirectory: dir)
+        let a = Repository(name: "A", path: "/tmp/mv-p-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/mv-p-b-\(UUID().uuidString)")
+        let c = Repository(name: "C", path: "/tmp/mv-p-c-\(UUID().uuidString)")
+        await store.addRepository(a)
+        await store.addRepository(b)
+        await store.addRepository(c)
+        let vm = RepositoryListViewModel(store: store, userDefaults: testDefaults)
+        await vm.loadRepositories()
+
+        await vm.moveRepository(c.id, to: a.id)
+
+        let stored = await store.getRepositories()
+        #expect(stored.map(\.id) == [c.id, a.id, b.id])
+    }
 }

--- a/OhMyWorktreeTests/RepositoryStorePersistenceTests.swift
+++ b/OhMyWorktreeTests/RepositoryStorePersistenceTests.swift
@@ -304,4 +304,64 @@ final class RepositoryStorePersistenceTests {
 
         #expect(await store.getRepositories().isEmpty)
     }
+
+    // MARK: - reorderRepositories
+
+    @Test func reorderRepositories_reordersInMemory() async {
+        let store = makeStore()
+        let a = Repository(name: "A", path: "/tmp/ro-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/ro-b-\(UUID().uuidString)")
+        let c = Repository(name: "C", path: "/tmp/ro-c-\(UUID().uuidString)")
+        await store.addRepository(a)
+        await store.addRepository(b)
+        await store.addRepository(c)
+
+        await store.reorderRepositories(orderedIDs: [c.id, a.id, b.id])
+
+        let all = await store.getRepositories()
+        #expect(all.map(\.id) == [c.id, a.id, b.id])
+    }
+
+    @Test func reorderRepositories_persistsAcrossReload() async {
+        let store = makeStore()
+        let a = Repository(name: "A", path: "/tmp/rp-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/rp-b-\(UUID().uuidString)")
+        await store.addRepository(a)
+        await store.addRepository(b)
+
+        await store.reorderRepositories(orderedIDs: [b.id, a.id])
+
+        // A fresh store reading the same dir must decode the persisted new order.
+        let reloaded = makeStore()
+        let all = await reloaded.getRepositories()
+        #expect(all.map(\.id) == [b.id, a.id])
+    }
+
+    @Test func reorderRepositories_nonPermutation_isIgnored() async {
+        let store = makeStore()
+        let a = Repository(name: "A", path: "/tmp/rn-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/rn-b-\(UUID().uuidString)")
+        await store.addRepository(a)
+        await store.addRepository(b)
+
+        // A missing id plus an unknown id is not a full permutation → no change.
+        await store.reorderRepositories(orderedIDs: [b.id, UUID()])
+
+        let all = await store.getRepositories()
+        #expect(all.map(\.id) == [a.id, b.id])
+    }
+
+    @Test func reorderRepositories_duplicateIDs_isIgnored() async {
+        let store = makeStore()
+        let a = Repository(name: "A", path: "/tmp/rd-a-\(UUID().uuidString)")
+        let b = Repository(name: "B", path: "/tmp/rd-b-\(UUID().uuidString)")
+        await store.addRepository(a)
+        await store.addRepository(b)
+
+        // Same count as the store but a duplicated id (drops one) → must be rejected.
+        await store.reorderRepositories(orderedIDs: [b.id, b.id])
+
+        let all = await store.getRepositories()
+        #expect(all.map(\.id) == [a.id, b.id])
+    }
 }


### PR DESCRIPTION
## Summary

Implements three repository-sidebar features from the [Claude Design](https://claude.ai/design) handoff (`Oh My Worktree.html`) that were present in the prototype but not yet in the app:

1. **Empty state** — when no repositories are tracked, the worktree list/detail area is replaced with the prototype's `.omw-empty` block: a `folder-git-2` art tile, a "No Repositories" title, a subtitle, an **Add Repository…** primary pill button, and a "drop a `.git` folder" hint. The hint is functional — dropping a folder adds the repository. The status bar is hidden while empty.
2. **Repository context menu** — right-click a sidebar row for **Show in Finder**, **Copy Path** (⌘C), and **Remove Repository…**. Removal shows a confirmation alert reassuring the user that the repo and its worktrees stay on disk.
3. **Drag-to-reorder** — sidebar rows can be reordered by drag and drop, with an accent insertion line on the drop target (matching `.sb-row.drop-target`). The new order is persisted to disk.

## Implementation notes

- Reorder logic is test-driven and lives in coverage-gated files:
  - `RepositoryListViewModel.moveRepository(_:to:)` mirrors the prototype's `reorderRepos` splice semantics.
  - `RepositoryStore.reorderRepositories(orderedIDs:)` only accepts a true permutation of the current IDs, so a stale or partial drag can never drop a repository.
- View code (empty state, context menu, drag wiring) lives under `Views/**`, which is excluded from the coverage gate by design.

## Decisions / minor deviations from the prototype

- The remove-confirmation message omits the exact worktree **count** from the prototype copy, because the app only knows the count for the *selected* repository while the context menu can target any row. Wording is otherwise verbatim.
- The dragged-row 0.4 opacity (`.dragging`) is omitted — the modern `.draggable` API has no drag-start hook — and macOS's native drag preview substitutes for it. The drop-target insertion line (the key affordance) is implemented.

## Testing

- 9 new tests (4 store reorder + 5 view-model move), written test-first (red → green).
- ✅ 419 tests pass (36 suites)
- ✅ Strict 100% coverage gate passes (22 files)
- ✅ SwiftLint clean
- ✅ App builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
