### PR TITLE
Redesign New Worktree base-branch selector

### DIFF
--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
@@ -67,6 +67,22 @@ extension WorktreeListViewModel {
         return (try? await worktreeManager.listBranches(repositoryPath: repository.path)) ?? []
     }
 
+    /// The branch the New Worktree sheet should pre-select: prefer `main`, then
+    /// `master`, else the first available branch (`main` when the list is empty).
+    nonisolated static func defaultBaseBranch(from branches: [String]) -> String {
+        if branches.contains("main") { return "main" }
+        if branches.contains("master") { return "master" }
+        return branches.first ?? "main"
+    }
+
+    /// Branches whose name contains `query` (case-insensitive, trimmed); all
+    /// branches when the query is blank. Powers the New Worktree sheet's "More…" filter.
+    nonisolated static func filterBranches(_ branches: [String], matching query: String) -> [String] {
+        let needle = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !needle.isEmpty else { return branches }
+        return branches.filter { $0.lowercased().contains(needle) }
+    }
+
     /// Loads ahead/behind, diff stat, and recent commits for the given worktree.
     /// Drive from a SwiftUI `.task(id:)` so it cancels and reloads on reselection.
     func loadDetail(for worktree: Worktree?) async {

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -83,6 +83,10 @@ struct ContentView: View {
                 worktreeViewModel: worktreeViewModel,
                 repoName: repoViewModel.selectedRepository?.name ?? "this repository"
             )
+            // `.sheet` does not inherit custom EnvironmentValues from the presenter,
+            // so inject the accent here or the segments/Create button fall back to
+            // the omwAccent @Entry default. See project_omwswitch_needs_omwaccent_injection.
+            .environment(\.omwAccent, accent)
         }
         .sheet(isPresented: $worktreeViewModel.isShowingSettings) {
             settingsSheet

--- a/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
+++ b/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
@@ -14,6 +14,9 @@ struct CreateWorktreeSheet: View {
     @State private var baseBranch = ""
     @State private var copyFiles = true
     @State private var branches: [String] = []
+    @State private var showBranchPicker = false
+    @State private var branchFilter = ""
+    @FocusState private var branchFilterFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -56,12 +59,7 @@ struct CreateWorktreeSheet: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("Base branch").font(.system(size: 12, weight: .semibold)).foregroundStyle(.secondary)
-                Picker("", selection: $baseBranch) {
-                    if branches.isEmpty { Text("main").tag("main") }
-                    ForEach(branches, id: \.self) { Text($0).tag($0) }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
+                baseBranchPicker
             }
 
             HStack(spacing: 12) {
@@ -96,13 +94,139 @@ struct CreateWorktreeSheet: View {
         .padding(.init(top: 12, leading: 20, bottom: 16, trailing: 20))
     }
 
+    // MARK: - Base branch selector
+
+    /// The repo's default branch (main/master) — label & value of the first segment.
+    private var defaultBranchName: String {
+        WorktreeListViewModel.defaultBaseBranch(from: branches)
+    }
+
+    /// True when `baseBranch` was chosen via "More…" rather than a fixed segment.
+    private var isCustomBaseBranch: Bool {
+        !baseBranch.isEmpty && baseBranch != defaultBranchName && baseBranch != "HEAD"
+    }
+
+    // NOTE: the selected segment is filled with the accent color by product
+    // decision — a deliberate deviation from the prototype's components.css, which
+    // specs `.mac-seg` selections as neutral `--control-bg` (see Settings tabs).
+    private var baseBranchPicker: some View {
+        HStack(spacing: 2) {
+            baseSegment(label: defaultBranchName, value: defaultBranchName)
+            baseSegment(label: "Current HEAD", value: "HEAD")
+            moreSegment
+            Spacer(minLength: 0)
+        }
+        .padding(2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(OMWColor.fillTertiary, in: RoundedRectangle(cornerRadius: OMWRadius.md))
+    }
+
+    private func baseSegment(label: String, value: String) -> some View {
+        let selected = baseBranch == value
+        return Button { baseBranch = value } label: {
+            Text(label)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+                .foregroundStyle(selected ? Color.white : OMWColor.labelSecondary)
+                .padding(.horizontal, 12)
+                .frame(height: 24)
+                .background(selected ? AnyShapeStyle(accent) : AnyShapeStyle(Color.clear),
+                            in: RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var moreSegment: some View {
+        let selected = isCustomBaseBranch
+        return Button {
+            branchFilter = ""
+            showBranchPicker = true
+        } label: {
+            HStack(spacing: 4) {
+                Text(selected ? baseBranch : "More…")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: selected ? 180 : nil, alignment: .leading)
+                Image(systemName: "chevron.down").font(.system(size: 9, weight: .semibold))
+            }
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(selected ? Color.white : OMWColor.labelSecondary)
+            .padding(.horizontal, 12)
+            .frame(height: 24)
+            .background(selected ? AnyShapeStyle(accent) : AnyShapeStyle(Color.clear),
+                        in: RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showBranchPicker, arrowEdge: .bottom) { branchPickerPopover }
+    }
+
+    private var branchPickerPopover: some View {
+        VStack(spacing: 0) {
+            TextField("Filter branches…", text: $branchFilter)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 12))
+                .focused($branchFilterFocused)
+                .onSubmit { if let first = filteredBranches.first { select(first) } }
+                .padding(8)
+            Divider()
+            branchList
+        }
+        .frame(width: 260)
+        .onAppear { branchFilterFocused = true }
+    }
+
+    @ViewBuilder private var branchList: some View {
+        let matches = filteredBranches
+        if matches.isEmpty {
+            Text(branches.isEmpty ? "No branches" : "No matching branches")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(matches, id: \.self) { branch in
+                        Button { select(branch) } label: { branchRow(branch) }
+                            .buttonStyle(.plain)
+                    }
+                }
+            }
+            .frame(maxHeight: 220)
+        }
+    }
+
+    private func branchRow(_ branch: String) -> some View {
+        HStack(spacing: 8) {
+            Text(branch).font(.system(size: 12)).lineLimit(1).truncationMode(.middle)
+            Spacer(minLength: 0)
+            if baseBranch == branch {
+                Image(systemName: "checkmark").font(.system(size: 10, weight: .bold)).foregroundStyle(accent)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+
+    private var filteredBranches: [String] {
+        WorktreeListViewModel.filterBranches(branches, matching: branchFilter)
+    }
+
+    private func select(_ branch: String) {
+        baseBranch = branch
+        showBranchPicker = false
+        branchFilter = ""
+    }
+
     private func load() {
         if name.isEmpty { name = randomName() }
         copyFiles = globalCopy
         Task {
             let list = await worktreeViewModel.availableBranches()
             branches = list
-            if baseBranch.isEmpty { baseBranch = list.first ?? "main" }
+            if baseBranch.isEmpty { baseBranch = WorktreeListViewModel.defaultBaseBranch(from: list) }
         }
     }
 

--- a/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
+++ b/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
@@ -25,7 +25,8 @@ struct CreateWorktreeSheet: View {
             Divider()
             footer
         }
-        .frame(width: 460)
+        .frame(width: 480)
+        .background(.regularMaterial)
         .tint(accent)
         .onAppear(perform: load)
     }
@@ -49,8 +50,16 @@ struct CreateWorktreeSheet: View {
                     TextField("e.g. tokyo-lunch", text: $name)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                    Button { name = randomName() } label: { Image(systemName: "shuffle") }
-                        .help("Generate another")
+                    Button { name = randomName() } label: {
+                        Image(systemName: "shuffle")
+                            .font(.system(size: 14))
+                            .foregroundStyle(OMWColor.labelSecondary)
+                            .frame(width: 30, height: 30)
+                            .background(OMWColor.controlBg, in: Circle())
+                            .overlay(Circle().strokeBorder(OMWColor.separator, lineWidth: 0.5))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Generate another")
                 }
                 Text("A new branch will be created and checked out.")
                     .font(.system(size: 11))
@@ -62,24 +71,24 @@ struct CreateWorktreeSheet: View {
                 baseBranchPicker
             }
 
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Copy files to new worktree").font(.system(size: 13, weight: .medium))
-                    Text("Apply .worktreeinclude patterns (.env*, local configs)")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
+            SettingsCard {
+                SettingsRow(icon: "doc.on.doc", title: "Copy files to new worktree",
+                            subtitle: "Apply .worktreeinclude patterns (.env*, local configs)") {
+                    Toggle("Copy files to new worktree", isOn: $copyFiles).toggleStyle(.omwSwitch)
                 }
-                Spacer(minLength: 10)
-                Toggle("Copy files to new worktree", isOn: $copyFiles).toggleStyle(.omwSwitch)
             }
         }
-        .padding(20)
+        .padding(.init(top: 16, leading: 20, bottom: 16, trailing: 20))
     }
 
     private var footer: some View {
         HStack {
             Spacer()
-            Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
+            Button("Cancel") { dismiss() }
+                .keyboardShortcut(.cancelAction)
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.capsule)
+                .controlSize(.large)
             Button("Create Worktree") {
                 let chosen = name
                 let base = baseBranch
@@ -89,6 +98,8 @@ struct CreateWorktreeSheet: View {
             }
             .keyboardShortcut(.defaultAction)
             .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+            .controlSize(.large)
             .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
         }
         .padding(.init(top: 12, leading: 20, bottom: 16, trailing: 20))

--- a/OhMyWorktreeTests/DefaultBaseBranchTests.swift
+++ b/OhMyWorktreeTests/DefaultBaseBranchTests.swift
@@ -1,0 +1,56 @@
+import Testing
+
+@testable import OhMyWorktree
+
+/// `WorktreeListViewModel.defaultBaseBranch(from:)` picks which branch the
+/// New Worktree sheet pre-selects: prefer `main`, then `master`, else the first
+/// available branch (or `main` when the list is empty).
+struct DefaultBaseBranchTests {
+
+    @Test func prefersMainWhenPresent() {
+        #expect(WorktreeListViewModel.defaultBaseBranch(from: ["agile-eagle", "main", "zeta"]) == "main")
+    }
+
+    @Test func prefersSecondChoiceWhenMainAbsent() {
+        #expect(WorktreeListViewModel.defaultBaseBranch(from: ["agile-eagle", "master", "zeta"]) == "master")
+    }
+
+    @Test func mainWinsWhenBothPresent() {
+        #expect(WorktreeListViewModel.defaultBaseBranch(from: ["master", "main"]) == "main")
+    }
+
+    @Test func fallsBackToFirstWhenNeitherPresent() {
+        #expect(WorktreeListViewModel.defaultBaseBranch(from: ["agile-eagle", "zeta"]) == "agile-eagle")
+    }
+
+    @Test func fallsBackToMainWhenEmpty() {
+        #expect(WorktreeListViewModel.defaultBaseBranch(from: []) == "main")
+    }
+}
+
+/// `WorktreeListViewModel.filterBranches(_:matching:)` powers the New Worktree
+/// sheet's "More…" branch search: case-insensitive substring match, trimmed,
+/// returning every branch when the query is blank.
+struct BranchFilterTests {
+    private let branches = ["main", "develop", "feature/login", "feature/signup", "release/2.0"]
+
+    @Test func emptyQueryReturnsAll() {
+        #expect(WorktreeListViewModel.filterBranches(branches, matching: "") == branches)
+    }
+
+    @Test func whitespaceQueryReturnsAll() {
+        #expect(WorktreeListViewModel.filterBranches(branches, matching: "   ") == branches)
+    }
+
+    @Test func matchesCaseInsensitiveSubstring() {
+        #expect(WorktreeListViewModel.filterBranches(branches, matching: "FEATURE") == ["feature/login", "feature/signup"])
+    }
+
+    @Test func matchesAnywhereInName() {
+        #expect(WorktreeListViewModel.filterBranches(branches, matching: "login") == ["feature/login"])
+    }
+
+    @Test func noMatchReturnsEmpty() {
+        #expect(WorktreeListViewModel.filterBranches(branches, matching: "zzz").isEmpty)
+    }
+}


### PR DESCRIPTION
## What & why

The New Worktree sheet's **Base branch** picker picks a sensible default and gets a searchable selector, and the sheet's chrome is matched to the Tahoe design prototype.

### Base branch
- **Default to main/master.** Previously defaulted to the alphabetically-first branch (e.g. `agile-eagle`). Now prefers `main`, then `master`, falling back to the first branch (then `"main"`) when neither exists.
- **Segmented control** replaces the dropdown: `[default branch] [Current HEAD] [More…]`.
  - **Selected segment is accent-filled** — a deliberate deviation from the prototype's gray `.mac-seg`, kept per request (inline `NOTE:`).
  - **Current HEAD** bases the worktree on the repo's current `HEAD`.
  - **More…** opens a searchable popover (type to filter, Enter/click to pick).
- Extracted pure, unit-tested helpers `defaultBaseBranch(from:)` and `filterBranches(_:matching:)`.

### Prototype chrome (precise match, except the base-branch area)
- **Accent reaches the sheet.** SwiftUI `.sheet` doesn't propagate custom `EnvironmentValues`, so `\.omwAccent` fell back to its default. Injected directly on the sheet content in `ContentView`.
- **Translucent glass background** (`.regularMaterial`, width 480) so the sheet reads as liquid glass and the accent selection behind it bleeds through as the prototype's soft glow (was a flat opaque panel).
- **Copy-files row → raised card** (`SettingsCard`/`SettingsRow`) matching the prototype's `.set-section`.
- **Capsule (pill) Cancel/Create buttons**; **circular shuffle button** by the name field.

### Testing
- `swiftlint lint` → 0 violations.
- `xcodebuild … OhMyWorktreeTests` → 420 tests pass.
- Changed production files (`ContentView.swift`, `CreateWorktreeSheet.swift`, `WorktreeListViewModel+Creation.swift`) are on the coverage exclusion list (SwiftUI views / quarantined VM), so the strict 100% gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
