### PR TITLE
Render Settings and New Worktree as translucent Liquid Glass

### DIFF
--- a/OhMyWorktree/Views/Components/GlassSheet.swift
+++ b/OhMyWorktree/Views/Components/GlassSheet.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+extension View {
+    /// Applies the Liquid-Glass backing for Settings and New Worktree sheets.
+    func glassSheet() -> some View {
+        self
+            .background {
+                GlassSheetBackground()
+            }
+            .clipShape(GlassSheetShape())
+            .overlay {
+                GlassSheetShape().strokeBorder(OMWColor.separator, lineWidth: 0.5)
+            }
+            .presentationBackground(.clear)
+    }
+}
+
+private struct GlassSheetShape: InsettableShape {
+    var insetAmount: CGFloat = 0
+
+    func path(in rect: CGRect) -> Path {
+        RoundedRectangle(cornerRadius: OMWRadius.xxl, style: .continuous)
+            .inset(by: insetAmount)
+            .path(in: rect)
+    }
+
+    func inset(by amount: CGFloat) -> GlassSheetShape {
+        var shape = self
+        shape.insetAmount += amount
+        return shape
+    }
+}
+
+private struct GlassSheetBackground: View {
+    var body: some View {
+        GlassSheetShape()
+            .fill(OMWColor.glassSheetTint)
+            .glassEffect(.regular, in: GlassSheetShape())
+            .overlay(alignment: .top) {
+                OMWColor.glassHighlight
+                    .frame(height: 1)
+                    .clipShape(GlassSheetShape())
+            }
+    }
+}

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
                 }
             }
             shortcutButtons
+            modalOverlay
         }
         .tint(accent)
         .environment(\.omwAccent, accent)
@@ -54,19 +55,6 @@ struct ContentView: View {
         }
         .sheet(isPresented: $worktreeViewModel.isShowingImportPR) {
             ImportPRView(worktreeViewModel: worktreeViewModel)
-        }
-        .sheet(isPresented: $worktreeViewModel.isShowingCreateSheet) {
-            CreateWorktreeSheet(
-                worktreeViewModel: worktreeViewModel,
-                repoName: repoViewModel.selectedRepository?.name ?? "this repository"
-            )
-            // `.sheet` does not inherit custom EnvironmentValues from the presenter,
-            // so inject the accent here or the segments/Create button fall back to
-            // the omwAccent @Entry default. See project_omwswitch_needs_omwaccent_injection.
-            .environment(\.omwAccent, accent)
-        }
-        .sheet(isPresented: $worktreeViewModel.isShowingSettings) {
-            settingsSheet
         }
         .alert(
             "Error",
@@ -233,8 +221,46 @@ struct ContentView: View {
     @ViewBuilder
     private var settingsSheet: some View {
         if let updaterManager {
-            SettingsSheetContent(updaterManager: updaterManager, store: shortcutStore)
+            SettingsSheetContent(
+                updaterManager: updaterManager,
+                store: shortcutStore,
+                onDismiss: { worktreeViewModel.isShowingSettings = false }
+            )
         }
+    }
+
+    @ViewBuilder
+    private var modalOverlay: some View {
+        if worktreeViewModel.isShowingCreateSheet {
+            glassModal {
+                CreateWorktreeSheet(
+                    worktreeViewModel: worktreeViewModel,
+                    repoName: repoViewModel.selectedRepository?.name ?? "this repository",
+                    onDismiss: { worktreeViewModel.isShowingCreateSheet = false }
+                )
+                .environment(\.omwAccent, accent)
+            }
+        } else if worktreeViewModel.isShowingSettings {
+            glassModal {
+                settingsSheet
+            }
+        }
+    }
+
+    private func glassModal<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        ZStack {
+            Color.black.opacity(0.46)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { }
+
+            content()
+                .shadow(color: .black.opacity(0.36), radius: 28, y: 18)
+                .padding(.horizontal, 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea(.container, edges: .top)
+        .zIndex(20)
     }
 
     private var shortcutButtons: some View {

--- a/OhMyWorktree/Views/SettingsSheetContent.swift
+++ b/OhMyWorktree/Views/SettingsSheetContent.swift
@@ -11,6 +11,7 @@ private let settingsLogger = Logger(subsystem: "com.ohmyworktree", category: "Se
 struct SettingsSheetContent: View {
     var updaterManager: UpdaterManager
     var store: ShortcutStore
+    var onDismiss: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @AppStorage("accentColorName") private var accentColorName = AccentChoice.default.rawValue
@@ -45,16 +46,26 @@ struct SettingsSheetContent: View {
             Divider()
             HStack {
                 Spacer()
-                Button("Done") { dismiss() }
+                Button("Done") { close() }
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
             }
             .padding(.init(top: 12, leading: 20, bottom: 16, trailing: 20))
         }
-        .frame(width: 500, height: 540)
-        .background(.regularMaterial)
+        .frame(width: 480, height: 540)
+        // Liquid Glass: a thin behind-window material so the worktree window reads
+        // through. See project_glass_sheets_need_presentationbackground.
+        .glassSheet()
         .tint(accent)
         .environment(\.omwAccent, accent)
+    }
+
+    private func close() {
+        if let onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
     }
 
     @ViewBuilder private var tabContent: some View {

--- a/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
+++ b/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct CreateWorktreeSheet: View {
     @Bindable var worktreeViewModel: WorktreeListViewModel
     var repoName: String
+    var onDismiss: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.omwAccent) private var accent
@@ -26,7 +27,9 @@ struct CreateWorktreeSheet: View {
             footer
         }
         .frame(width: 480)
-        .background(.regularMaterial)
+        // Liquid Glass backdrop — matches the Settings sheet.
+        // See project_glass_sheets_need_presentationbackground.
+        .glassSheet()
         .tint(accent)
         .onAppear(perform: load)
     }
@@ -84,7 +87,7 @@ struct CreateWorktreeSheet: View {
     private var footer: some View {
         HStack {
             Spacer()
-            Button("Cancel") { dismiss() }
+            Button("Cancel") { close() }
                 .keyboardShortcut(.cancelAction)
                 .buttonStyle(.bordered)
                 .buttonBorderShape(.capsule)
@@ -94,7 +97,7 @@ struct CreateWorktreeSheet: View {
                 let base = baseBranch
                 let copy = copyFiles
                 Task { await worktreeViewModel.addWorktree(name: chosen, baseBranch: base, copyFiles: copy) }
-                dismiss()
+                close()
             }
             .keyboardShortcut(.defaultAction)
             .buttonStyle(.borderedProminent)
@@ -103,6 +106,14 @@ struct CreateWorktreeSheet: View {
             .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
         }
         .padding(.init(top: 12, leading: 20, bottom: 16, trailing: 20))
+    }
+
+    private func close() {
+        if let onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
     }
 
     // MARK: - Base branch selector

--- a/OhMyWorktree/Views/Theme/OMWTheme.swift
+++ b/OhMyWorktree/Views/Theme/OMWTheme.swift
@@ -44,6 +44,12 @@ enum OMWColor {
     static let sidebar = dynamic(light: (246, 246, 248, 0.66), dark: (40, 40, 42, 0.62))
     /// Control background (search field, round toolbar buttons, action-bar chips).
     static let controlBg = dynamic(light: (255, 255, 255, 1), dark: (255, 255, 255, 0.1))
+    /// Thin tint over native sheet glass. Keep alpha low so the parent window's
+    /// selection colors and columns read through the blur.
+    static let glassSheetTint = dynamic(light: (255, 255, 255, 0.58), dark: (34, 34, 36, 0.66))
+    /// Top inner sheen on Liquid-Glass surfaces (`--glass-highlight`): a 1px white
+    /// line along the upper edge of sheets/popovers that sells the glass rim.
+    static let glassHighlight = dynamic(light: (255, 255, 255, 0.6), dark: (255, 255, 255, 0.12))
 
     // MARK: System palette (mode-independent)
     static let sysRed = solid(255, 56, 60)


### PR DESCRIPTION
## Summary

The **Settings** and **New Worktree** sheets rendered as flat, opaque panels instead of the prototype's translucent Liquid Glass. SwiftUI's `Material` blends *within-window*, but a native `.sheet()` has nothing behind it inside the sheet window, so `.background(.regularMaterial)` composited solid.

Both are now presented as **in-window glass modal overlays** (a scrim + centered card in `ContentView`), so the backing blends within-window against the worktree window behind it and reads through as real Liquid Glass.

## Changes

- **`ContentView`** — replace the `.sheet(isPresented:)` presentations for Create/Settings with a `modalOverlay` (dimming scrim + centered card) rendered in the window's `ZStack`.
- **`GlassSheet.swift`** (new) — `glassSheet()` modifier: macOS Tahoe `.glassEffect(.regular)` over a thin `glassSheetTint`, a 1px top sheen (`glassHighlight`), a continuous rounded-22 clip, and a 0.5px hairline border.
- **`OMWTheme`** — add `glassSheetTint` and `glassHighlight` tokens.
- **`SettingsSheetContent` / `CreateWorktreeSheet`** — swap `.background(.regularMaterial)` for `.glassSheet()`; take an `onDismiss` closure, since an in-window overlay is not a presentation context for `\.dismiss`.

## Test plan

- `swiftlint lint` — clean
- `xcodebuild -scheme OhMyWorktree build` — **BUILD SUCCEEDED**
- `xcodebuild -scheme OhMyWorktreeTests test` — **429 tests / 38 suites passed**
- Verified visually: Settings and New Worktree now show the worktree window reading through the glass instead of a solid panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
