### PR TITLE
Fix "Show icon in Dock" by launching as a menu-bar agent

### DIFF
--- a/OhMyWorktree/Info.plist
+++ b/OhMyWorktree/Info.plist
@@ -24,6 +24,8 @@
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>SUFeedURL</key>

--- a/OhMyWorktree/OhMyWorktreeApp.swift
+++ b/OhMyWorktree/OhMyWorktreeApp.swift
@@ -23,6 +23,10 @@ struct OhMyWorktreeApp: App {
         .defaultSize(width: 1180, height: 740)
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentMinSize)
+        // Menu-bar agent: don't auto-open this window at launch. Windows are
+        // opened on demand (status item, hotkey, Dock-icon reopen) via
+        // AppDelegate.showOrCreateMainWindow().
+        .defaultLaunchBehavior(.suppressed)
         .commands {
             CommandGroup(replacing: .appSettings) {
                 Button("Settings...") {

--- a/project.yml
+++ b/project.yml
@@ -65,6 +65,10 @@ targets:
         CFBundleIdentifier: com.ohmyworktree.app
         CFBundleInfoDictionaryVersion: "6.0"
         CFBundlePackageType: APPL
+        # Launch as a menu-bar agent: no Dock icon / no auto-opened window at
+        # launch. The app promotes to .regular at runtime when a window opens
+        # (WindowObserver) or when "Show icon in Dock" is enabled (DockPolicy).
+        LSUIElement: true
         CFBundleShortVersionString: "2.0.2"
         CFBundleVersion: "15"
         LSApplicationCategoryType: public.app-category.developer-tools


### PR DESCRIPTION
## Problem

The **Show icon in Dock** toggle had no observable effect.

The app shipped without `LSUIElement`, so it launched as a regular app and the SwiftUI `WindowGroup` auto-opened a window at launch — which forced `.regular` (Dock icon) **regardless of the setting**. And because the Settings UI is an in-window overlay (`ContentView.modalOverlay`), a window is always open while the toggle is visible, so `WindowObserver.updateActivationPolicy()` always computed `.regular` (`hasAppWindows == true`) and the toggle's notification was effectively a no-op at interaction time.

Net effect: in every situation where you could see or flip the switch, a window already forced the Dock icon on — so flipping it changed nothing.

## Fix

Make the app a true menu-bar agent:

- `project.yml`: add `LSUIElement: true` → launches as an accessory (no Dock icon, no auto-opened window).
- `OhMyWorktreeApp.swift`: add `.defaultLaunchBehavior(.suppressed)` → the `WindowGroup` window isn't auto-opened at launch; windows open on demand (status item, hotkey, Dock-icon reopen) via `AppDelegate.showOrCreateMainWindow()`.

`DockPolicy` / `WindowObserver` logic is unchanged — it already promotes to `.regular` when a window opens or when the toggle is on, and returns to `.accessory` otherwise.

## Verification

Measured activation policy (`lsappinfo`) and on-screen window count (`CGWindowList`) on a real build:

| Scenario | Before | After |
| --- | --- | --- |
| `showInDock=false`, launch | Foreground + auto-window ❌ | **UIElement · 0 windows** ✅ (menu-bar only) |
| `showInDock=true`, launch | Foreground + auto-window | **Foreground · 0 windows** ✅ (Dock icon, no window) |
| Reopen (status item / Dock click) | — | **Foreground · 1 window** ✅ (opens on demand) |

## Checks

- ✅ `swiftlint` clean
- ✅ 429 tests pass
- ✅ Coverage gate passes (strict 100%, 22 files). Both source-affecting files are coverage-excluded (`OhMyWorktreeApp.swift`); `project.yml` / `Info.plist` are config.

## Note / tradeoff

Launching from Finder/Spotlight no longer auto-opens a window — only the menu-bar icon appears. Windows open via the menu-bar icon, the global hotkey, or clicking the Dock icon (when shown). A first-run welcome window could be added separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
