### PR TITLE
Add menu bar toggle for showing the worktree name

### DIFF
--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -65,6 +65,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupStatusItem()
         windowObserver.startObserving()
         registerGlobalHotkeyHandler()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(menuBarTitleSettingChanged),
+            name: .menuBarTitleSettingChanged,
+            object: nil
+        )
+    }
+
+    /// Refreshes the status-item title when the "Show worktree name in menu bar"
+    /// toggle changes. Mirrors the `.showInDockSettingChanged` pattern.
+    @objc private func menuBarTitleSettingChanged() {
+        updateStatusItemTitle()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -167,12 +180,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 )
             }
             button.imagePosition = .imageLeading
-            button.title = " Oh My Worktree"
         }
 
         let menu = NSMenu()
         menu.delegate = self
         statusItem?.menu = menu
+
+        // Reflect the persisted "show worktree name" toggle (default: icon only).
+        updateStatusItemTitle()
     }
 
     // MARK: - Global Hotkey Setup
@@ -200,15 +215,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func updateStatusItemTitle() {
         guard let button = statusItem?.button else { return }
 
-        if let repo = repoViewModel?.selectedRepository {
-            if let worktree = worktreeViewModel?.selectedWorktree {
-                let branchDisplay = worktree.customName ?? liveBranchName ?? worktree.displayName
-                button.title = " \(repo.name)/\(branchDisplay)"
-            } else {
-                button.title = " \(repo.name)"
-            }
-        } else {
-            button.title = " Oh My Worktree"
+        let worktreeName = worktreeViewModel?.selectedWorktree.map { worktree in
+            worktree.customName ?? liveBranchName ?? worktree.displayName
         }
+        button.title = MenuBarTitle.text(
+            showWorktreeName: UserDefaults.standard.bool(forKey: MenuBarTitle.showWorktreeNameKey),
+            repoName: repoViewModel?.selectedRepository?.name,
+            worktreeName: worktreeName
+        )
     }
+}
+
+extension Notification.Name {
+    /// Posted when the user toggles "Show worktree name in menu bar".
+    /// `AppDelegate` refreshes the status-item title in response.
+    static let menuBarTitleSettingChanged = Notification.Name("com.ohmyworktree.menuBarTitleSettingChanged")
 }

--- a/OhMyWorktree/Services/MenuBarTitle.swift
+++ b/OhMyWorktree/Services/MenuBarTitle.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Computes the menu bar status-item title from the user's "show worktree name"
+/// preference and the current selection. Extracted as a pure function so the
+/// logic is testable (the `AppDelegate` that calls it is coverage-excluded).
+enum MenuBarTitle {
+
+    /// `UserDefaults` / `@AppStorage` key backing the "Show worktree name in
+    /// menu bar" toggle. Default is `false` (icon only).
+    static let showWorktreeNameKey = "showWorktreeNameInMenuBar"
+
+    /// Resolves the status-item title.
+    ///
+    /// - Parameters:
+    ///   - showWorktreeName: the user's toggle. When `false`, returns `""` so the
+    ///     status item shows only its icon.
+    ///   - repoName: the selected repository name, or `nil`.
+    ///   - worktreeName: the resolved worktree label, or `nil`.
+    /// - Returns: the title string (with a leading space separating it from the
+    ///   icon), or `""` when the toggle is off.
+    static func text(showWorktreeName: Bool, repoName: String?, worktreeName: String?) -> String {
+        guard showWorktreeName else { return "" }
+        guard let repoName else { return " Oh My Worktree" }
+        if let worktreeName { return " \(repoName)/\(worktreeName)" }
+        return " \(repoName)"
+    }
+}

--- a/OhMyWorktree/Views/SettingsSheetContent.swift
+++ b/OhMyWorktree/Views/SettingsSheetContent.swift
@@ -146,6 +146,7 @@ func settingsHairline() -> some View {
 private struct GeneralTab: View {
     @AppStorage("copyEnvFilesEnabled") private var copyEnvFilesEnabled = true
     @AppStorage(DockPolicy.defaultsKey) private var showInDock = false
+    @AppStorage(MenuBarTitle.showWorktreeNameKey) private var showWorktreeName = false
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
     var body: some View {
@@ -166,6 +167,14 @@ private struct GeneralTab: View {
                 Toggle("Show icon in Dock", isOn: $showInDock).toggleStyle(.omwSwitch)
                     .onChange(of: showInDock) { _, _ in
                         NotificationCenter.default.post(name: .showInDockSettingChanged, object: nil)
+                    }
+            }
+            settingsHairline()
+            SettingsRow(icon: "menubar.rectangle", title: "Show worktree name in menu bar",
+                        subtitle: "Display the repository and worktree next to the menu bar icon") {
+                Toggle("Show worktree name in menu bar", isOn: $showWorktreeName).toggleStyle(.omwSwitch)
+                    .onChange(of: showWorktreeName) { _, _ in
+                        NotificationCenter.default.post(name: .menuBarTitleSettingChanged, object: nil)
                     }
             }
         }

--- a/OhMyWorktreeTests/MenuBarTitleTests.swift
+++ b/OhMyWorktreeTests/MenuBarTitleTests.swift
@@ -1,0 +1,42 @@
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct MenuBarTitleTests {
+
+    @Test func showWorktreeNameKeyIsStable() {
+        #expect(MenuBarTitle.showWorktreeNameKey == "showWorktreeNameInMenuBar")
+    }
+
+    @Test func emptyWhenToggleOffEvenWithRepoAndWorktree() {
+        #expect(
+            MenuBarTitle.text(showWorktreeName: false, repoName: "repo", worktreeName: "feature/x") == ""
+        )
+    }
+
+    @Test func emptyWhenToggleOffAndNothingSelected() {
+        #expect(
+            MenuBarTitle.text(showWorktreeName: false, repoName: nil, worktreeName: nil) == ""
+        )
+    }
+
+    @Test func fallbackTitleWhenToggleOnAndNoRepo() {
+        #expect(
+            MenuBarTitle.text(showWorktreeName: true, repoName: nil, worktreeName: nil) == " Oh My Worktree"
+        )
+    }
+
+    @Test func repoOnlyWhenToggleOnAndNoWorktree() {
+        #expect(
+            MenuBarTitle.text(showWorktreeName: true, repoName: "repo", worktreeName: nil) == " repo"
+        )
+    }
+
+    @Test func repoAndWorktreeWhenToggleOnAndBothPresent() {
+        #expect(
+            MenuBarTitle.text(showWorktreeName: true, repoName: "repo", worktreeName: "feature/x")
+                == " repo/feature/x"
+        )
+    }
+}

--- a/docs/superpowers/specs/2026-06-07-menu-bar-worktree-name-toggle-design.md
+++ b/docs/superpowers/specs/2026-06-07-menu-bar-worktree-name-toggle-design.md
@@ -1,0 +1,159 @@
+# Menu Bar Worktree-Name Toggle — Design
+
+- **Date:** 2026-06-07
+- **Status:** Approved (pending spec review)
+- **Branch:** `claude/musing-galileo-272ac5` (worktree)
+
+## Summary
+
+Add a Settings toggle that controls whether the menu bar status item shows only
+its icon, or the icon followed by the current `repository/worktree` label. The
+default is **icon only**.
+
+## Background — Current Behavior
+
+`AppDelegate.updateStatusItemTitle()` (`OhMyWorktree/AppDelegate.swift:200`)
+**always** sets a text title next to the icon:
+
+- repo + worktree selected → `" <repo>/<worktree>"`
+- repo only → `" <repo>"`
+- nothing → `" Oh My Worktree"`
+
+There is no way to hide this text. The worktree label shown is
+`worktree.customName ?? liveBranchName ?? worktree.displayName`.
+
+### Settings UI reality
+
+The repo has two settings surfaces, but only one is live:
+
+- `SettingsSheetContent` (Liquid Glass sheet) — **the live UI**. Every entry
+  point (app menu, shortcut, window button) sets
+  `worktreeViewModel.isShowingSettings = true`, which presents this sheet.
+- `SettingsView` (legacy `TabView`) + `GeneralSettingsView` — reached only via
+  `AppDelegate.showOrCreateSettingsWindow()`, which **has no callers**. Dead code.
+
+→ The new toggle goes into `SettingsSheetContent`'s `GeneralTab` only. The legacy
+views are intentionally left untouched (YAGNI).
+
+### Coverage constraint
+
+`AppDelegate.swift` and `AppDelegate+*.swift` are on the coverage exclusion list
+(`coverage-exclude.txt`). To keep the title logic testable and improve coverage,
+the decision logic is extracted into a pure function (same strategy as
+`DockPolicy`), which is **not** excluded and therefore requires 100% coverage.
+
+## Requirements
+
+1. A toggle in Settings → General: "Show worktree name in menu bar".
+2. Default **off** → menu bar shows the icon only (empty title).
+3. When **on** → behavior identical to today: `" <repo>/<worktree>"` /
+   `" <repo>"` / `" Oh My Worktree"`.
+4. Toggling applies immediately, no app restart.
+
+## Design
+
+### 1. Pure function — `OhMyWorktree/Services/MenuBarTitle.swift` (new)
+
+```swift
+enum MenuBarTitle {
+    /// UserDefaults / @AppStorage key backing the toggle. Default: false (icon only).
+    static let showWorktreeNameKey = "showWorktreeNameInMenuBar"
+
+    /// Resolves the status-item title.
+    /// - showWorktreeName: the user's toggle. When false, returns "" (icon only).
+    /// - repoName: selected repository name, or nil.
+    /// - worktreeName: resolved worktree label, or nil.
+    static func text(showWorktreeName: Bool, repoName: String?, worktreeName: String?) -> String {
+        guard showWorktreeName else { return "" }
+        guard let repoName else { return " Oh My Worktree" }
+        if let worktreeName { return " \(repoName)/\(worktreeName)" }
+        return " \(repoName)"
+    }
+}
+```
+
+The leading space matches the existing format (icon uses `.imageLeading`, so the
+space separates icon and text).
+
+### 2. `AppDelegate` changes (`AppDelegate.swift`)
+
+`updateStatusItemTitle()` delegates to the pure function:
+
+```swift
+func updateStatusItemTitle() {
+    guard let button = statusItem?.button else { return }
+    let showName = UserDefaults.standard.bool(forKey: MenuBarTitle.showWorktreeNameKey)
+    let worktreeName = worktreeViewModel?.selectedWorktree.map { wt in
+        wt.customName ?? liveBranchName ?? wt.displayName
+    }
+    button.title = MenuBarTitle.text(
+        showWorktreeName: showName,
+        repoName: repoViewModel?.selectedRepository?.name,
+        worktreeName: worktreeName
+    )
+}
+```
+
+`setupStatusItem()` currently hardcodes `button.title = " Oh My Worktree"`.
+Remove that hardcoded assignment and call `updateStatusItemTitle()` at the end of
+`setupStatusItem()` instead. At setup time the view models are not injected yet
+(`repoViewModel`/`worktreeViewModel` are nil), so the call resolves to `""` when
+the toggle is off (default) or `" Oh My Worktree"` when it is on — the correct
+initial state in both cases.
+
+### 3. Immediate apply — Notification
+
+Add to the existing `extension Notification.Name`:
+
+```swift
+static let menuBarTitleSettingChanged = Notification.Name("com.ohmyworktree.menuBarTitleSettingChanged")
+```
+
+`AppDelegate` subscribes (e.g. in `applicationDidFinishLaunching`, guarded by the
+existing `!isRunningTests` path) and calls `updateStatusItemTitle()` on receipt.
+This mirrors the proven `.showInDockSettingChanged` → `WindowObserver` pattern.
+
+### 4. Settings UI — `SettingsSheetContent.swift`, `GeneralTab`
+
+Add one `SettingsRow` after the "Show icon in Dock" row:
+
+```swift
+@AppStorage(MenuBarTitle.showWorktreeNameKey) private var showWorktreeName = false
+...
+settingsHairline()
+SettingsRow(icon: "menubar.rectangle", title: "Show worktree name in menu bar",
+            subtitle: "Display the repository and worktree next to the menu bar icon") {
+    Toggle("Show worktree name in menu bar", isOn: $showWorktreeName).toggleStyle(.omwSwitch)
+        .onChange(of: showWorktreeName) { _, _ in
+            NotificationCenter.default.post(name: .menuBarTitleSettingChanged, object: nil)
+        }
+}
+```
+
+## Testing
+
+New `OhMyWorktreeTests/MenuBarTitleTests.swift` covering every branch of
+`MenuBarTitle.text`:
+
+- `showWorktreeName = false` → `""` (independent of repo/worktree being set)
+- `true`, repo `nil` → `" Oh My Worktree"`
+- `true`, repo set, worktree `nil` → `" <repo>"`
+- `true`, repo set, worktree set → `" <repo>/<worktree>"`
+
+This yields 100% coverage for `MenuBarTitle.swift`. AppDelegate edits are within
+the excluded files, so no additional gating; the pure function carries the logic.
+
+## Out of Scope
+
+- Legacy `SettingsView` / `GeneralSettingsView` (dead code) — not modified.
+- Truncation / max-width handling of long labels — `NSStatusItem.variableLength`
+  already handles layout; no change.
+- Per-repository or per-worktree overrides.
+
+## Verification
+
+Per `CLAUDE.md`, before committing:
+
+- `swiftlint lint`
+- `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test`
+- `scripts/coverage.sh` (confirm `MenuBarTitle.swift` is 100%)


### PR DESCRIPTION
## Summary

The menu bar status item always showed the `<repo>/<worktree>` label next to the icon, with no way to hide it. This adds a **Settings → General** toggle — **"Show worktree name in menu bar"** — controlling whether the status item shows only its icon (the new default) or the icon followed by the repository/worktree label.

## Changes

- **`MenuBarTitle`** (new) — a pure function that computes the status-item title from the toggle + current selection. Unit-tested to 100% (the calling `AppDelegate` is coverage-excluded), mirroring the `DockPolicy` strategy.
- **`AppDelegate`** — `updateStatusItemTitle()` and `setupStatusItem()` now delegate to `MenuBarTitle`, and the title refreshes live via a new `.menuBarTitleSettingChanged` notification (same pattern as `.showInDockSettingChanged`).
- **`GeneralTab`** — new `.omwSwitch` row, default **off** (icon only).

## Behavior

| Toggle | Menu bar |
|--------|----------|
| Off (default) | icon only |
| On | icon + ` <repo>/<worktree>` (previous behavior) |

## Testing

- `swiftlint lint` — 0 violations
- Full test suite — **435 tests pass**
- `scripts/coverage.sh` — **strict 100% on 23 files** (incl. `MenuBarTitle.swift`)

## Spec

`docs/superpowers/specs/2026-06-07-menu-bar-worktree-name-toggle-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)