### PR TITLE
Fix 1px corner seam on Liquid Glass sheets

### DIFF
--- a/OhMyWorktree/Views/Components/GlassSheet.swift
+++ b/OhMyWorktree/Views/Components/GlassSheet.swift
@@ -9,7 +9,7 @@ extension View {
             }
             .clipShape(GlassSheetShape())
             .overlay {
-                GlassSheetShape().strokeBorder(OMWColor.separator, lineWidth: 0.5)
+                GlassSheetShape().strokeBorder(OMWColor.separator, lineWidth: GlassSheetMetrics.hairlineWidth)
             }
             .presentationBackground(.clear)
     }
@@ -19,7 +19,7 @@ private struct GlassSheetShape: InsettableShape {
     var insetAmount: CGFloat = 0
 
     func path(in rect: CGRect) -> Path {
-        RoundedRectangle(cornerRadius: OMWRadius.xxl, style: .continuous)
+        RoundedRectangle(cornerRadius: GlassSheetMetrics.cornerRadius, style: .continuous)
             .inset(by: insetAmount)
             .path(in: rect)
     }
@@ -35,11 +35,13 @@ private struct GlassSheetBackground: View {
     var body: some View {
         GlassSheetShape()
             .fill(OMWColor.glassSheetTint)
-            .glassEffect(.regular, in: GlassSheetShape())
+            .glassEffect(.regular, in: GlassSheetShape().inset(by: GlassSheetMetrics.glassMaterialInset))
             .overlay(alignment: .top) {
-                OMWColor.glassHighlight
-                    .frame(height: 1)
-                    .clipShape(GlassSheetShape())
+                Rectangle()
+                    .fill(OMWColor.glassHighlight)
+                    .frame(height: GlassSheetMetrics.topHighlightHeight)
+                    .padding(.horizontal, GlassSheetMetrics.topHighlightHorizontalInset)
+                    .padding(.top, GlassSheetMetrics.topHighlightVerticalInset)
             }
     }
 }

--- a/OhMyWorktree/Views/Components/GlassSheetMetrics.swift
+++ b/OhMyWorktree/Views/Components/GlassSheetMetrics.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+enum GlassSheetMetrics {
+    static let cornerRadius: CGFloat = OMWRadius.xxl
+    static let hairlineWidth: CGFloat = 0.5
+    static let glassMaterialInset: CGFloat = hairlineWidth
+    static let topHighlightHeight: CGFloat = 1
+    static let topHighlightHorizontalInset: CGFloat = cornerRadius
+    static let topHighlightVerticalInset: CGFloat = hairlineWidth
+}

--- a/OhMyWorktreeTests/GlassSheetMetricsTests.swift
+++ b/OhMyWorktreeTests/GlassSheetMetricsTests.swift
@@ -1,0 +1,16 @@
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct GlassSheetMetricsTests {
+
+    @Test func topHighlightStaysInsideRoundedCorners() {
+        #expect(GlassSheetMetrics.topHighlightHorizontalInset >= GlassSheetMetrics.cornerRadius)
+        #expect(GlassSheetMetrics.topHighlightVerticalInset >= GlassSheetMetrics.hairlineWidth)
+    }
+
+    @Test func glassMaterialDoesNotShareTheOuterAntialiasedEdge() {
+        #expect(GlassSheetMetrics.glassMaterialInset >= GlassSheetMetrics.hairlineWidth)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the ~1px hairline that poked past the **top corners** of the Settings and New Worktree Liquid Glass sheets.

## Root cause

The `.glassEffect(.regular, in: GlassSheetShape())` material edge sat on the exact same boundary as the outer `.clipShape(GlassSheetShape())`. At a *continuous* corner's high-curvature apex, two coincident antialiased edges rasterize to a visible 1px seam ("ears" at the top corners).

Confirmed by elimination — rendering the top highlight, the `strokeBorder`, and the continuous-corner clip in isolation all produce clean corners; only the glass material, used with a rounded shape, triggers it (every other `.glassEffect` in the app passes `Rectangle()`, which has no corner curvature).

## Changes

- Inset the glass material by the hairline-border width (`glassMaterialInset = hairlineWidth`) so its edge sits *under* the border instead of coinciding with the outer clip. The tint fill still spans the full shape, so the inset leaves no visible gap.
- Inset the top sheen by the corner radius so it never reaches the corners.
- Extract the geometry constants into `GlassSheetMetrics` and cover the corner-containment invariants with unit tests.

## Test plan

- [x] `swiftlint lint` — 0 violations
- [x] `xcodebuild -scheme OhMyWorktreeTests ... test` — 437 tests pass (incl. new `GlassSheetMetricsTests`)
- [x] Settings / New Worktree sheet corners render clean (no protruding hairline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
