### PR TITLE
Apply stronger glass panels to popups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ release/
 # OMC state
 .omc/
 
+# Superpowers visual brainstorming session data
+.superpowers/
+
 # Claude Code internal session data
 .claude/worktrees/
 

--- a/OhMyWorktree/Views/Components/GlassSheet.swift
+++ b/OhMyWorktree/Views/Components/GlassSheet.swift
@@ -1,46 +1,95 @@
 import SwiftUI
 
 extension View {
-    /// Applies the Liquid-Glass backing for Settings and New Worktree sheets.
+    /// Applies the Liquid-Glass backing for Settings, New Worktree, and Import PR sheets.
     func glassSheet() -> some View {
+        glassPanel(kind: .sheet)
+            .presentationBackground(.clear)
+    }
+
+    /// Applies the compact Liquid-Glass backing for popovers.
+    func glassPopover() -> some View {
+        glassPanel(kind: .popover)
+            .presentationBackground(.clear)
+    }
+
+    private func glassPanel(kind: GlassPanelKind) -> some View {
         self
             .background {
-                GlassSheetBackground()
+                GlassPanelBackground(kind: kind)
             }
-            .clipShape(GlassSheetShape())
+            .clipShape(GlassPanelShape(cornerRadius: kind.cornerRadius))
             .overlay {
-                GlassSheetShape().strokeBorder(OMWColor.separator, lineWidth: GlassSheetMetrics.hairlineWidth)
+                GlassPanelShape(cornerRadius: kind.cornerRadius)
+                    .strokeBorder(OMWColor.separator, lineWidth: GlassSheetMetrics.hairlineWidth)
             }
-            .presentationBackground(.clear)
     }
 }
 
-private struct GlassSheetShape: InsettableShape {
+private enum GlassPanelKind {
+    case sheet
+    case popover
+
+    var cornerRadius: CGFloat {
+        switch self {
+        case .sheet: GlassSheetMetrics.cornerRadius
+        case .popover: GlassSheetMetrics.popoverCornerRadius
+        }
+    }
+
+    var materialInset: CGFloat {
+        switch self {
+        case .sheet: GlassSheetMetrics.glassMaterialInset
+        case .popover: GlassSheetMetrics.popoverGlassMaterialInset
+        }
+    }
+
+    var topHighlightHorizontalInset: CGFloat {
+        switch self {
+        case .sheet: GlassSheetMetrics.topHighlightHorizontalInset
+        case .popover: GlassSheetMetrics.popoverTopHighlightHorizontalInset
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .sheet: OMWColor.glassSheetTint
+        case .popover: OMWColor.glassPopoverTint
+        }
+    }
+}
+
+private struct GlassPanelShape: InsettableShape {
+    var cornerRadius: CGFloat
     var insetAmount: CGFloat = 0
 
     func path(in rect: CGRect) -> Path {
-        RoundedRectangle(cornerRadius: GlassSheetMetrics.cornerRadius, style: .continuous)
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
             .inset(by: insetAmount)
             .path(in: rect)
     }
 
-    func inset(by amount: CGFloat) -> GlassSheetShape {
+    func inset(by amount: CGFloat) -> GlassPanelShape {
         var shape = self
         shape.insetAmount += amount
         return shape
     }
 }
 
-private struct GlassSheetBackground: View {
+private struct GlassPanelBackground: View {
+    var kind: GlassPanelKind
+
     var body: some View {
-        GlassSheetShape()
-            .fill(OMWColor.glassSheetTint)
-            .glassEffect(.regular, in: GlassSheetShape().inset(by: GlassSheetMetrics.glassMaterialInset))
+        let shape = GlassPanelShape(cornerRadius: kind.cornerRadius)
+
+        shape
+            .fill(kind.tint)
+            .glassEffect(.regular, in: shape.inset(by: kind.materialInset))
             .overlay(alignment: .top) {
                 Rectangle()
                     .fill(OMWColor.glassHighlight)
                     .frame(height: GlassSheetMetrics.topHighlightHeight)
-                    .padding(.horizontal, GlassSheetMetrics.topHighlightHorizontalInset)
+                    .padding(.horizontal, kind.topHighlightHorizontalInset)
                     .padding(.top, GlassSheetMetrics.topHighlightVerticalInset)
             }
     }

--- a/OhMyWorktree/Views/Components/GlassSheetMetrics.swift
+++ b/OhMyWorktree/Views/Components/GlassSheetMetrics.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 enum GlassSheetMetrics {
     static let cornerRadius: CGFloat = OMWRadius.xxl
+    static let popoverCornerRadius: CGFloat = OMWRadius.xl
     static let hairlineWidth: CGFloat = 0.5
     static let glassMaterialInset: CGFloat = hairlineWidth
+    static let popoverGlassMaterialInset: CGFloat = hairlineWidth
     static let topHighlightHeight: CGFloat = 1
     static let topHighlightHorizontalInset: CGFloat = cornerRadius
+    static let popoverTopHighlightHorizontalInset: CGFloat = popoverCornerRadius
     static let topHighlightVerticalInset: CGFloat = hairlineWidth
+    static let modalScrimOpacity: Double = 0.32
 }

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -53,9 +53,6 @@ struct ContentView: View {
                 repoViewModel.errorMessage = error.localizedDescription
             }
         }
-        .sheet(isPresented: $worktreeViewModel.isShowingImportPR) {
-            ImportPRView(worktreeViewModel: worktreeViewModel)
-        }
         .alert(
             "Error",
             isPresented: .init(
@@ -244,12 +241,20 @@ struct ContentView: View {
             glassModal {
                 settingsSheet
             }
+        } else if worktreeViewModel.isShowingImportPR {
+            glassModal {
+                ImportPRView(
+                    worktreeViewModel: worktreeViewModel,
+                    onDismiss: { worktreeViewModel.isShowingImportPR = false }
+                )
+                .environment(\.omwAccent, accent)
+            }
         }
     }
 
     private func glassModal<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         ZStack {
-            Color.black.opacity(0.46)
+            Color.black.opacity(GlassSheetMetrics.modalScrimOpacity)
                 .ignoresSafeArea()
                 .contentShape(Rectangle())
                 .onTapGesture { }

--- a/OhMyWorktree/Views/ImportPRView.swift
+++ b/OhMyWorktree/Views/ImportPRView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ImportPRView: View {
     var worktreeViewModel: WorktreeListViewModel
+    var onDismiss: (() -> Void)?
     @State private var viewModel = ImportPRViewModel()
     @Environment(\.dismiss) private var dismiss
     @State private var selectedID: Int?
@@ -14,7 +15,8 @@ struct ImportPRView: View {
             Divider()
             footerArea
         }
-        .frame(minWidth: 420, minHeight: 320)
+        .frame(width: 700, height: 480)
+        .glassSheet()
         .onAppear {
             viewModel.repositoryPath = worktreeViewModel.repository?.path ?? ""
             viewModel.repositoryName = worktreeViewModel.repository?.name ?? ""
@@ -42,8 +44,16 @@ struct ImportPRView: View {
         FooterAreaView(
             viewModel: viewModel,
             worktreeViewModel: worktreeViewModel,
-            dismiss: dismiss
+            onDismiss: close
         )
+    }
+
+    private func close() {
+        if let onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
     }
 }
 
@@ -162,13 +172,13 @@ private struct ContentAreaView: View {
 private struct FooterAreaView: View {
     var viewModel: ImportPRViewModel
     var worktreeViewModel: WorktreeListViewModel
-    let dismiss: DismissAction
+    let onDismiss: () -> Void
 
     var body: some View {
         HStack {
             Spacer()
 
-            Button("Cancel") { dismiss() }
+            Button("Cancel", action: onDismiss)
                 .keyboardShortcut(.cancelAction)
 
             Button("Import Worktree") {
@@ -176,7 +186,7 @@ private struct FooterAreaView: View {
                 if let error = worktreeViewModel.addWorktreeFromPR(pr) {
                     viewModel.errorMessage = error
                 } else {
-                    dismiss()
+                    onDismiss()
                 }
             }
             .keyboardShortcut(.defaultAction)

--- a/OhMyWorktree/Views/MainWindow/WindowStatusBar.swift
+++ b/OhMyWorktree/Views/MainWindow/WindowStatusBar.swift
@@ -94,6 +94,7 @@ struct WindowStatusBar: View {
                 onRetry: { job in worktreeViewModel.jobQueue.retry(job.id) },
                 onClear: { worktreeViewModel.jobQueue.clearFailed(); showTasks = false }
             )
+            .glassPopover()
         }
     }
 

--- a/OhMyWorktree/Views/QueueStatusBarView.swift
+++ b/OhMyWorktree/Views/QueueStatusBarView.swift
@@ -172,6 +172,7 @@ private struct QueueBarView: View {
         }
         .popover(isPresented: $showingQueueDetail, arrowEdge: .bottom) {
             QueueDetailPopoverView(queue: queue)
+                .glassPopover()
         }
     }
 }

--- a/OhMyWorktree/Views/RepositorySelectorView.swift
+++ b/OhMyWorktree/Views/RepositorySelectorView.swift
@@ -72,6 +72,7 @@ struct RepositorySelectorView: View {
                             repository: repo,
                             store: viewModel.store
                         )
+                        .glassPopover()
                     }
                 }
             }

--- a/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
+++ b/OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift
@@ -194,6 +194,7 @@ struct CreateWorktreeSheet: View {
             branchList
         }
         .frame(width: 260)
+        .glassPopover()
         .onAppear { branchFilterFocused = true }
     }
 

--- a/OhMyWorktree/Views/Theme/OMWTheme.swift
+++ b/OhMyWorktree/Views/Theme/OMWTheme.swift
@@ -44,12 +44,14 @@ enum OMWColor {
     static let sidebar = dynamic(light: (246, 246, 248, 0.66), dark: (40, 40, 42, 0.62))
     /// Control background (search field, round toolbar buttons, action-bar chips).
     static let controlBg = dynamic(light: (255, 255, 255, 1), dark: (255, 255, 255, 0.1))
-    /// Thin tint over native sheet glass. Keep alpha low so the parent window's
-    /// selection colors and columns read through the blur.
-    static let glassSheetTint = dynamic(light: (255, 255, 255, 0.58), dark: (34, 34, 36, 0.66))
+    /// Thin tint over native sheet glass. Kept low so the parent window's
+    /// selection colors and columns read through the stronger glass blur.
+    static let glassSheetTint = dynamic(light: (255, 255, 255, 0.46), dark: (34, 34, 36, 0.46))
+    /// Compact popover tint using the same stronger Liquid Glass direction.
+    static let glassPopoverTint = dynamic(light: (255, 255, 255, 0.50), dark: (34, 34, 36, 0.50))
     /// Top inner sheen on Liquid-Glass surfaces (`--glass-highlight`): a 1px white
     /// line along the upper edge of sheets/popovers that sells the glass rim.
-    static let glassHighlight = dynamic(light: (255, 255, 255, 0.6), dark: (255, 255, 255, 0.12))
+    static let glassHighlight = dynamic(light: (255, 255, 255, 0.72), dark: (255, 255, 255, 0.22))
 
     // MARK: System palette (mode-independent)
     static let sysRed = solid(255, 56, 60)

--- a/OhMyWorktreeTests/AppDelegateColdStartTests.swift
+++ b/OhMyWorktreeTests/AppDelegateColdStartTests.swift
@@ -127,6 +127,11 @@ final class AppDelegateColdStartTests {
         try await pollUntil { worktreeVM.isShowingImportPR }
     }
 
+    @Test func importPRViewAcceptsOverlayDismissCallback() {
+        let worktreeVM = WorktreeListViewModel()
+        _ = ImportPRView(worktreeViewModel: worktreeVM, onDismiss: {})
+    }
+
     // MARK: - Window reuse (no duplicates)
 
     @Test func mainWindowIsReused() async throws {

--- a/OhMyWorktreeTests/GlassSheetMetricsTests.swift
+++ b/OhMyWorktreeTests/GlassSheetMetricsTests.swift
@@ -34,4 +34,9 @@ struct GlassSheetMetricsTests {
         let view = Text("Popover").glassPopover()
         #expect(String(describing: type(of: view)).isEmpty == false)
     }
+
+    @Test func popoverRadiusRemainsLargeEnoughForLiquidGlassRim() {
+        #expect(GlassSheetMetrics.popoverCornerRadius >= OMWRadius.xl)
+        #expect(GlassSheetMetrics.topHighlightHeight == 1)
+    }
 }

--- a/OhMyWorktreeTests/GlassSheetMetricsTests.swift
+++ b/OhMyWorktreeTests/GlassSheetMetricsTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import Testing
 
 @testable import OhMyWorktree
@@ -27,5 +28,10 @@ struct GlassSheetMetricsTests {
 
     @Test func popoverGlassMaterialDoesNotShareTheOuterAntialiasedEdge() {
         #expect(GlassSheetMetrics.popoverGlassMaterialInset >= GlassSheetMetrics.hairlineWidth)
+    }
+
+    @Test func glassPopoverModifierIsAvailableForCompactPresentedSurfaces() {
+        let view = Text("Popover").glassPopover()
+        #expect(String(describing: type(of: view)).isEmpty == false)
     }
 }

--- a/OhMyWorktreeTests/GlassSheetMetricsTests.swift
+++ b/OhMyWorktreeTests/GlassSheetMetricsTests.swift
@@ -13,4 +13,19 @@ struct GlassSheetMetricsTests {
     @Test func glassMaterialDoesNotShareTheOuterAntialiasedEdge() {
         #expect(GlassSheetMetrics.glassMaterialInset >= GlassSheetMetrics.hairlineWidth)
     }
+
+    @Test func modalScrimIsWeakEnoughForBackgroundToReadThrough() {
+        #expect(GlassSheetMetrics.modalScrimOpacity < 0.40)
+        #expect(GlassSheetMetrics.modalScrimOpacity > 0.20)
+    }
+
+    @Test func popoverGlassUsesCompactRoundingInsideSheetRounding() {
+        #expect(GlassSheetMetrics.popoverCornerRadius < GlassSheetMetrics.cornerRadius)
+        #expect(GlassSheetMetrics.popoverCornerRadius >= OMWRadius.lg)
+        #expect(GlassSheetMetrics.popoverTopHighlightHorizontalInset >= GlassSheetMetrics.popoverCornerRadius)
+    }
+
+    @Test func popoverGlassMaterialDoesNotShareTheOuterAntialiasedEdge() {
+        #expect(GlassSheetMetrics.popoverGlassMaterialInset >= GlassSheetMetrics.hairlineWidth)
+    }
 }

--- a/docs/superpowers/plans/2026-06-08-popup-glass-panels.md
+++ b/docs/superpowers/plans/2026-06-08-popup-glass-panels.md
@@ -1,0 +1,622 @@
+# Popup Glass Panels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the approved stronger Liquid Glass style to custom sheets and popovers, and move Import PR off native macOS sheet presentation so it can share the same translucent glass panel.
+
+**Architecture:** Keep the visual treatment centralized in `GlassSheet.swift` and `GlassSheetMetrics.swift`. `ContentView` remains the owner of app-level modal overlays, while individual popover call sites opt into a new `glassPopover()` modifier inside their existing `.popover` closures.
+
+**Tech Stack:** Swift 5.9, SwiftUI on macOS 26, Swift Testing, existing `OMWColor`/`OMWRadius` design tokens.
+
+---
+
+## File Structure
+
+- Modify `OhMyWorktree/Views/Components/GlassSheetMetrics.swift`: add testable metrics for stronger modal scrim and popover glass geometry.
+- Modify `OhMyWorktree/Views/Components/GlassSheet.swift`: refactor the sheet-only implementation into a shared glass panel implementation with `glassSheet()` and `glassPopover()`.
+- Modify `OhMyWorktree/Views/Theme/OMWTheme.swift`: lower sheet tint alpha, add popover tint, and strengthen highlight alpha.
+- Modify `OhMyWorktree/Views/ContentView.swift`: remove native Import PR `.sheet` and present Import PR through `modalOverlay` with the shared custom glass backing.
+- Modify `OhMyWorktree/Views/ImportPRView.swift`: add an optional close callback, use it for Cancel and successful import, set stable overlay dimensions, and apply `glassSheet()`.
+- Modify `OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift`: apply `glassPopover()` to the branch picker popover content.
+- Modify `OhMyWorktree/Views/MainWindow/WindowStatusBar.swift`: apply `glassPopover()` to the background tasks popover.
+- Modify `OhMyWorktree/Views/QueueStatusBarView.swift`: apply `glassPopover()` to the queue detail popover.
+- Modify `OhMyWorktree/Views/RepositorySelectorView.swift`: apply `glassPopover()` to the repository settings popover.
+- Modify `OhMyWorktreeTests/GlassSheetMetricsTests.swift`: add focused tests for the new shared metrics.
+
+### Task 1: Stronger Shared Glass Metrics
+
+**Files:**
+- Modify: `OhMyWorktreeTests/GlassSheetMetricsTests.swift`
+- Modify: `OhMyWorktree/Views/Components/GlassSheetMetrics.swift`
+- Modify: `OhMyWorktree/Views/Theme/OMWTheme.swift`
+
+- [ ] **Step 1: Write failing metric tests**
+
+Add these tests to `OhMyWorktreeTests/GlassSheetMetricsTests.swift`:
+
+```swift
+    @Test func modalScrimIsWeakEnoughForBackgroundToReadThrough() {
+        #expect(GlassSheetMetrics.modalScrimOpacity < 0.40)
+        #expect(GlassSheetMetrics.modalScrimOpacity > 0.20)
+    }
+
+    @Test func popoverGlassUsesCompactRoundingInsideSheetRounding() {
+        #expect(GlassSheetMetrics.popoverCornerRadius < GlassSheetMetrics.cornerRadius)
+        #expect(GlassSheetMetrics.popoverCornerRadius >= OMWRadius.lg)
+        #expect(GlassSheetMetrics.popoverTopHighlightHorizontalInset >= GlassSheetMetrics.popoverCornerRadius)
+    }
+
+    @Test func popoverGlassMaterialDoesNotShareTheOuterAntialiasedEdge() {
+        #expect(GlassSheetMetrics.popoverGlassMaterialInset >= GlassSheetMetrics.hairlineWidth)
+    }
+```
+
+- [ ] **Step 2: Run metric tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/GlassSheetMetricsTests
+```
+
+Expected: FAIL because `modalScrimOpacity`, `popoverCornerRadius`, `popoverTopHighlightHorizontalInset`, and `popoverGlassMaterialInset` do not exist yet.
+
+- [ ] **Step 3: Add minimal metrics**
+
+Update `OhMyWorktree/Views/Components/GlassSheetMetrics.swift` to:
+
+```swift
+import SwiftUI
+
+enum GlassSheetMetrics {
+    static let cornerRadius: CGFloat = OMWRadius.xxl
+    static let popoverCornerRadius: CGFloat = OMWRadius.xl
+    static let hairlineWidth: CGFloat = 0.5
+    static let glassMaterialInset: CGFloat = hairlineWidth
+    static let popoverGlassMaterialInset: CGFloat = hairlineWidth
+    static let topHighlightHeight: CGFloat = 1
+    static let topHighlightHorizontalInset: CGFloat = cornerRadius
+    static let popoverTopHighlightHorizontalInset: CGFloat = popoverCornerRadius
+    static let topHighlightVerticalInset: CGFloat = hairlineWidth
+    static let modalScrimOpacity: Double = 0.32
+}
+```
+
+Update the glass color section of `OhMyWorktree/Views/Theme/OMWTheme.swift` to:
+
+```swift
+    /// Thin tint over native sheet glass. Kept low so the parent window's
+    /// selection colors and columns read through the stronger glass blur.
+    static let glassSheetTint = dynamic(light: (255, 255, 255, 0.46), dark: (34, 34, 36, 0.46))
+    /// Compact popover tint using the same stronger Liquid Glass direction.
+    static let glassPopoverTint = dynamic(light: (255, 255, 255, 0.50), dark: (34, 34, 36, 0.50))
+    /// Top inner sheen on Liquid-Glass surfaces (`--glass-highlight`): a 1px white
+    /// line along the upper edge of sheets/popovers that sells the glass rim.
+    static let glassHighlight = dynamic(light: (255, 255, 255, 0.72), dark: (255, 255, 255, 0.22))
+```
+
+- [ ] **Step 4: Run metric tests to verify GREEN**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/GlassSheetMetricsTests
+```
+
+Expected: PASS for `GlassSheetMetricsTests`.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add OhMyWorktreeTests/GlassSheetMetricsTests.swift OhMyWorktree/Views/Components/GlassSheetMetrics.swift OhMyWorktree/Views/Theme/OMWTheme.swift
+git commit -m "Tune stronger glass panel metrics"
+```
+
+### Task 2: Shared Glass Panel Modifier
+
+**Files:**
+- Modify: `OhMyWorktree/Views/Components/GlassSheet.swift`
+- Test: `OhMyWorktreeTests/GlassSheetMetricsTests.swift`
+
+- [ ] **Step 1: Write failing API availability test for popover glass**
+
+Add `import SwiftUI` to `OhMyWorktreeTests/GlassSheetMetricsTests.swift`, then add this test:
+
+```swift
+    @Test func glassPopoverModifierIsAvailableForCompactPresentedSurfaces() {
+        let view = Text("Popover").glassPopover()
+        #expect(String(describing: type(of: view)).isEmpty == false)
+    }
+```
+
+- [ ] **Step 2: Run metric tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/GlassSheetMetricsTests
+```
+
+Expected: FAIL to compile with `Value of type 'Text' has no member 'glassPopover'`.
+
+- [ ] **Step 3: Refactor `GlassSheet.swift` into shared sheet/popover implementation**
+
+Replace `OhMyWorktree/Views/Components/GlassSheet.swift` with:
+
+```swift
+import SwiftUI
+
+extension View {
+    /// Applies the Liquid-Glass backing for Settings, New Worktree, and Import PR sheets.
+    func glassSheet() -> some View {
+        glassPanel(kind: .sheet)
+            .presentationBackground(.clear)
+    }
+
+    /// Applies the compact Liquid-Glass backing for popovers.
+    func glassPopover() -> some View {
+        glassPanel(kind: .popover)
+            .presentationBackground(.clear)
+    }
+
+    private func glassPanel(kind: GlassPanelKind) -> some View {
+        self
+            .background {
+                GlassPanelBackground(kind: kind)
+            }
+            .clipShape(GlassPanelShape(cornerRadius: kind.cornerRadius))
+            .overlay {
+                GlassPanelShape(cornerRadius: kind.cornerRadius)
+                    .strokeBorder(OMWColor.separator, lineWidth: GlassSheetMetrics.hairlineWidth)
+            }
+    }
+}
+
+private enum GlassPanelKind {
+    case sheet
+    case popover
+
+    var cornerRadius: CGFloat {
+        switch self {
+        case .sheet: GlassSheetMetrics.cornerRadius
+        case .popover: GlassSheetMetrics.popoverCornerRadius
+        }
+    }
+
+    var materialInset: CGFloat {
+        switch self {
+        case .sheet: GlassSheetMetrics.glassMaterialInset
+        case .popover: GlassSheetMetrics.popoverGlassMaterialInset
+        }
+    }
+
+    var topHighlightHorizontalInset: CGFloat {
+        switch self {
+        case .sheet: GlassSheetMetrics.topHighlightHorizontalInset
+        case .popover: GlassSheetMetrics.popoverTopHighlightHorizontalInset
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .sheet: OMWColor.glassSheetTint
+        case .popover: OMWColor.glassPopoverTint
+        }
+    }
+}
+
+private struct GlassPanelShape: InsettableShape {
+    var cornerRadius: CGFloat
+    var insetAmount: CGFloat = 0
+
+    func path(in rect: CGRect) -> Path {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .inset(by: insetAmount)
+            .path(in: rect)
+    }
+
+    func inset(by amount: CGFloat) -> GlassPanelShape {
+        var shape = self
+        shape.insetAmount += amount
+        return shape
+    }
+}
+
+private struct GlassPanelBackground: View {
+    var kind: GlassPanelKind
+
+    var body: some View {
+        let shape = GlassPanelShape(cornerRadius: kind.cornerRadius)
+
+        shape
+            .fill(kind.tint)
+            .glassEffect(.regular, in: shape.inset(by: kind.materialInset))
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(OMWColor.glassHighlight)
+                    .frame(height: GlassSheetMetrics.topHighlightHeight)
+                    .padding(.horizontal, kind.topHighlightHorizontalInset)
+                    .padding(.top, GlassSheetMetrics.topHighlightVerticalInset)
+            }
+    }
+}
+```
+
+- [ ] **Step 4: Run metric tests and build**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/GlassSheetMetricsTests
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build
+```
+
+Expected: metric tests PASS and app target builds.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add OhMyWorktreeTests/GlassSheetMetricsTests.swift OhMyWorktree/Views/Components/GlassSheet.swift
+git commit -m "Share glass panel styling with popovers"
+```
+
+### Task 3: Import PR Custom Glass Overlay
+
+**Files:**
+- Modify: `OhMyWorktree/Views/ContentView.swift`
+- Modify: `OhMyWorktree/Views/ImportPRView.swift`
+- Test: `OhMyWorktreeTests/AppDelegateColdStartTests.swift`
+
+- [ ] **Step 1: Add a failing overlay initializer test**
+
+Add this test after `importPRSetsSheetFlag()` in `OhMyWorktreeTests/AppDelegateColdStartTests.swift`:
+
+```swift
+    @Test func importPRViewAcceptsOverlayDismissCallback() {
+        let worktreeVM = WorktreeListViewModel()
+        _ = ImportPRView(worktreeViewModel: worktreeVM, onDismiss: {})
+    }
+```
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/AppDelegateColdStartTests/importPRViewAcceptsOverlayDismissCallback
+```
+
+Expected: FAIL to compile with `Extra argument 'onDismiss' in call`.
+
+- [ ] **Step 3: Convert ContentView from native sheet to custom overlay**
+
+In `OhMyWorktree/Views/ContentView.swift`, delete this modifier from `body`:
+
+```swift
+        .sheet(isPresented: $worktreeViewModel.isShowingImportPR) {
+            ImportPRView(worktreeViewModel: worktreeViewModel)
+        }
+```
+
+Then update `modalOverlay` to:
+
+```swift
+    @ViewBuilder
+    private var modalOverlay: some View {
+        if worktreeViewModel.isShowingCreateSheet {
+            glassModal {
+                CreateWorktreeSheet(
+                    worktreeViewModel: worktreeViewModel,
+                    repoName: repoViewModel.selectedRepository?.name ?? "this repository",
+                    onDismiss: { worktreeViewModel.isShowingCreateSheet = false }
+                )
+                .environment(\.omwAccent, accent)
+            }
+        } else if worktreeViewModel.isShowingImportPR {
+            glassModal {
+                ImportPRView(
+                    worktreeViewModel: worktreeViewModel,
+                    onDismiss: { worktreeViewModel.isShowingImportPR = false }
+                )
+                .environment(\.omwAccent, accent)
+            }
+        } else if worktreeViewModel.isShowingSettings {
+            glassModal {
+                settingsSheet
+            }
+        }
+    }
+```
+
+Finally update the scrim inside `glassModal` to:
+
+```swift
+            Color.black.opacity(GlassSheetMetrics.modalScrimOpacity)
+```
+
+- [ ] **Step 4: Add close callback and glass backing to ImportPRView**
+
+In `OhMyWorktree/Views/ImportPRView.swift`, change the top of `ImportPRView` to:
+
+```swift
+struct ImportPRView: View {
+    var worktreeViewModel: WorktreeListViewModel
+    var onDismiss: (() -> Void)?
+
+    @State private var viewModel = ImportPRViewModel()
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedID: Int?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerArea
+            Divider()
+            contentArea
+            Divider()
+            footerArea
+        }
+        .frame(width: 700, height: 480)
+        .glassSheet()
+        .onAppear {
+            viewModel.repositoryPath = worktreeViewModel.repository?.path ?? ""
+            viewModel.repositoryName = worktreeViewModel.repository?.name ?? ""
+            Task { await viewModel.loadPRs() }
+        }
+        .alert("Error", isPresented: Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+```
+
+Add this helper inside `ImportPRView`:
+
+```swift
+    private func close() {
+        if let onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
+    }
+```
+
+Update `footerArea` to pass the close callback:
+
+```swift
+    private var footerArea: some View {
+        FooterAreaView(
+            viewModel: viewModel,
+            worktreeViewModel: worktreeViewModel,
+            onDismiss: close
+        )
+    }
+```
+
+Update `FooterAreaView` to:
+
+```swift
+private struct FooterAreaView: View {
+    var viewModel: ImportPRViewModel
+    var worktreeViewModel: WorktreeListViewModel
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack {
+            Spacer()
+
+            Button("Cancel", action: onDismiss)
+                .keyboardShortcut(.cancelAction)
+
+            Button("Import Worktree") {
+                guard let pr = viewModel.selectedPR else { return }
+                if let error = worktreeViewModel.addWorktreeFromPR(pr) {
+                    viewModel.errorMessage = error
+                } else {
+                    onDismiss()
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(viewModel.selectedPR == nil)
+        }
+        .padding(16)
+    }
+}
+```
+
+- [ ] **Step 5: Run focused tests and build**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/AppDelegateColdStartTests/importPRSetsSheetFlag -only-testing:OhMyWorktreeTests/AppDelegateColdStartTests/importPRViewAcceptsOverlayDismissCallback
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build
+```
+
+Expected: focused tests PASS and app target builds.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add OhMyWorktreeTests/AppDelegateColdStartTests.swift OhMyWorktree/Views/ContentView.swift OhMyWorktree/Views/ImportPRView.swift
+git commit -m "Present Import PR with glass overlay"
+```
+
+### Task 4: Apply Glass Popovers
+
+**Files:**
+- Modify: `OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift`
+- Modify: `OhMyWorktree/Views/MainWindow/WindowStatusBar.swift`
+- Modify: `OhMyWorktree/Views/QueueStatusBarView.swift`
+- Modify: `OhMyWorktree/Views/RepositorySelectorView.swift`
+- Test: `OhMyWorktreeTests/GlassSheetMetricsTests.swift`
+
+- [ ] **Step 1: Run a failing static coverage check for popover call sites**
+
+Run:
+
+```bash
+for file in \
+  OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift \
+  OhMyWorktree/Views/MainWindow/WindowStatusBar.swift \
+  OhMyWorktree/Views/QueueStatusBarView.swift \
+  OhMyWorktree/Views/RepositorySelectorView.swift
+do
+  rg -q "glassPopover\\(\\)" "$file"
+done
+```
+
+Expected: FAIL because these popover call sites do not all use `glassPopover()` yet.
+
+- [ ] **Step 2: Add a regression test for popover radius hierarchy**
+
+Add this test to `OhMyWorktreeTests/GlassSheetMetricsTests.swift`:
+
+```swift
+    @Test func popoverRadiusRemainsLargeEnoughForLiquidGlassRim() {
+        #expect(GlassSheetMetrics.popoverCornerRadius >= OMWRadius.xl)
+        #expect(GlassSheetMetrics.topHighlightHeight == 1)
+    }
+```
+
+- [ ] **Step 3: Run metric tests**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/GlassSheetMetricsTests
+```
+
+Expected: PASS. This locks the compact popover geometry before applying it to all popover call sites.
+
+- [ ] **Step 4: Apply glassPopover to branch picker**
+
+In `OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift`, update `branchPickerPopover` to end with:
+
+```swift
+        .frame(width: 260)
+        .glassPopover()
+        .onAppear { branchFilterFocused = true }
+```
+
+- [ ] **Step 5: Apply glassPopover to background task popover**
+
+In `OhMyWorktree/Views/MainWindow/WindowStatusBar.swift`, update the `.popover` content to:
+
+```swift
+            BackgroundTasksPopover(
+                running: running,
+                failed: failed,
+                onSelect: { job in worktreeViewModel.selectedWorktreeIDs = [job.worktreeID]; showTasks = false },
+                onRetry: { job in worktreeViewModel.jobQueue.retry(job.id) },
+                onClear: { worktreeViewModel.jobQueue.clearFailed(); showTasks = false }
+            )
+            .glassPopover()
+```
+
+- [ ] **Step 6: Apply glassPopover to queue detail popover**
+
+In `OhMyWorktree/Views/QueueStatusBarView.swift`, update the `.popover` content to:
+
+```swift
+            QueueDetailPopoverView(queue: queue)
+                .glassPopover()
+```
+
+- [ ] **Step 7: Apply glassPopover to repository settings popover**
+
+In `OhMyWorktree/Views/RepositorySelectorView.swift`, update the repository settings popover content to:
+
+```swift
+                    if let repo = viewModel.selectedRepository {
+                        RepositorySettingsView(
+                            repository: repo,
+                            store: viewModel.store
+                        )
+                        .glassPopover()
+                    }
+```
+
+- [ ] **Step 8: Run static coverage check, build, and focused tests**
+
+Run:
+
+```bash
+for file in \
+  OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift \
+  OhMyWorktree/Views/MainWindow/WindowStatusBar.swift \
+  OhMyWorktree/Views/QueueStatusBarView.swift \
+  OhMyWorktree/Views/RepositorySelectorView.swift
+do
+  rg -q "glassPopover\\(\\)" "$file"
+done
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test -only-testing:OhMyWorktreeTests/GlassSheetMetricsTests
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build
+```
+
+Expected: static coverage check exits 0, metric tests PASS, and app target builds.
+
+- [ ] **Step 9: Commit Task 4**
+
+Run:
+
+```bash
+git add OhMyWorktreeTests/GlassSheetMetricsTests.swift OhMyWorktree/Views/Sheets/CreateWorktreeSheet.swift OhMyWorktree/Views/MainWindow/WindowStatusBar.swift OhMyWorktree/Views/QueueStatusBarView.swift OhMyWorktree/Views/RepositorySelectorView.swift
+git commit -m "Apply glass styling to popovers"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+- Verify all modified files
+
+- [ ] **Step 1: Run SwiftLint**
+
+Run:
+
+```bash
+swiftlint lint
+```
+
+Expected: `Done linting! Found 0 violations, 0 serious`.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+
+```bash
+xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test
+```
+
+Expected: `** TEST SUCCEEDED **`.
+
+- [ ] **Step 3: Manual app visual check**
+
+Run the app from Xcode or the built debug product and verify:
+
+- Settings, New Worktree, and Import PR use the stronger B-style glass.
+- Import PR appears as an app-owned overlay, not a native macOS sheet.
+- The modal scrim is lighter than before and the worktree list reads through the panel.
+- Branch picker, background tasks, queue detail, and repository settings popovers use the compact glass panel.
+- Text remains legible in dark and light appearance.
+
+- [ ] **Step 4: Commit any verification-only follow-up fixes**
+
+If verification required code changes, run:
+
+```bash
+git add OhMyWorktree OhMyWorktreeTests
+git commit -m "Polish popup glass verification fixes"
+```
+
+Expected: no commit is needed if verification found no follow-up fixes.

--- a/docs/superpowers/specs/2026-06-08-popup-glass-panels-design.md
+++ b/docs/superpowers/specs/2026-06-08-popup-glass-panels-design.md
@@ -1,0 +1,68 @@
+# Popup Glass Panels Design
+
+## Context
+
+Oh My Worktree already has a reusable `glassSheet()` modifier used by the custom Settings and New Worktree overlays. The current visual direction is too close to a dark translucent plate: the dimming layer and sheet tint reduce how much of the worktree UI reads through the popup.
+
+The app also still has popup surfaces that do not share the same glass treatment:
+
+- `ImportPRView` is presented with SwiftUI `.sheet`.
+- Branch picking, background tasks, queue details, and repository settings use SwiftUI `.popover`.
+- Alerts are system-owned SwiftUI/NSAlert presentations and are outside the custom glass panel scope.
+
+Apple's SwiftUI `presentationBackground` documentation notes that macOS sheet presentations do not support transparent sheet backgrounds, so custom overlays are the reliable path for sheet-like surfaces that must visually reveal the parent window behind them.
+
+## Approved Direction
+
+Use the visual option B: stronger Liquid Glass.
+
+The design should make popups feel more translucent and glass-like without making dense controls hard to read:
+
+- Lower the dark sheet tint so the parent window reads through more clearly.
+- Keep or increase the blur/glass effect to preserve separation and legibility.
+- Strengthen the top rim highlight and border enough to make the panel edge feel like glass.
+- Reduce the modal scrim opacity so the background does not collapse into a dark flat layer.
+- Apply the shared glass panel style consistently to custom sheets and popovers.
+
+## Scope
+
+In scope:
+
+- Tune shared glass tokens and metrics used by `glassSheet()`.
+- Add a reusable glass popover modifier if the existing sheet modifier is not flexible enough for small popovers.
+- Convert Import PR from a native SwiftUI `.sheet` to the same custom overlay pattern used by Settings and New Worktree, preserving dismissal behavior and keyboard shortcuts.
+- Apply glass styling to custom popover content for branch selection, background tasks, queue details, and repository settings.
+- Keep system alerts as native alerts; replacing them with app-owned confirmation overlays is explicitly separate future work.
+- Update focused tests for shared glass metrics and any presentation state behavior touched by the conversion.
+
+Out of scope:
+
+- Replacing all SwiftUI alerts/confirmation dialogs with custom dialogs.
+- Redesigning popup content layout beyond changes needed for glass legibility.
+- Changing app navigation or repository/worktree data flow.
+
+## Implementation Notes
+
+Use existing SwiftUI patterns and design tokens. Keep changes centralized so future popup surfaces can opt into the same appearance with one modifier.
+
+The likely implementation shape:
+
+- Adjust `OMWColor.glassSheetTint`, `OMWColor.glassHighlight`, and related shared metrics.
+- Extend `GlassSheet` with a popover-appropriate variant, or make the modifier configurable by size/context.
+- Add Import PR to `ContentView.modalOverlay` with the same `glassModal` backing used by other custom sheets.
+- Apply the popover variant inside each `.popover` content closure.
+- Avoid changing native system alert presentation in this pass.
+
+## Verification
+
+Run:
+
+- `swiftlint lint`
+- `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test`
+
+Manual visual checks:
+
+- Settings and New Worktree still have rounded, seamless glass corners.
+- Import PR uses the same stronger glass and shows the parent window through it.
+- Branch picker, background-task popovers, queue detail popover, and repository settings popover share the glass panel treatment.
+- Text and buttons remain legible in dark and light appearance.


### PR DESCRIPTION
## Summary
- Strengthen shared glass sheet metrics for a more translucent Liquid Glass effect.
- Add a reusable glass popover modifier and apply it to popovers across the app.
- Present Import PR with the custom glass overlay instead of the native sheet.

## Test Plan
- [x] `swiftlint lint`
- [x] `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test`
- [x] Launch Debug app and verify the main window renders

## Notes
- Popup-specific screenshot automation was limited by local accessibility/input permissions, so visual popup coverage is verified through implementation/static coverage plus the app launch check.
