### PR TITLE
Diff-aware copied files with apply-to-main

### DIFF
--- a/OhMyWorktree/Models/CopiedFile.swift
+++ b/OhMyWorktree/Models/CopiedFile.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// How a worktree's copied file relates to the repository's (main's) copy.
+enum CopiedFileStatus: Equatable, Sendable {
+    case identical   // bytes equal
+    case modified    // present in both, bytes differ
+    case new         // present in the worktree, absent in main
+
+    /// Differs from main (anything worth surfacing / applying).
+    var isChanged: Bool { self != .identical }
+    /// Has something to open (a diff to view or content to copy back).
+    var isClickable: Bool { self != .identical }
+    /// Ordering for chips/list: changed first, then new, then identical.
+    var sortRank: Int {
+        switch self {
+        case .modified: 0
+        case .new: 1
+        case .identical: 2
+        }
+    }
+}
+
+/// Splits a repo-relative path into its directory (with trailing slash) and filename.
+enum CopiedPath {
+    static func split(_ path: String) -> (dir: String, base: String) {
+        guard let slash = path.lastIndex(of: "/") else { return (dir: "", base: path) }
+        let after = path.index(after: slash)
+        return (dir: String(path[...slash]), base: String(path[after...]))
+    }
+}
+
+/// A `.worktreeinclude` copied file compared against main, with its line diff.
+struct CopiedFile: Equatable, Sendable, Identifiable {
+    let path: String
+    let status: CopiedFileStatus
+    let isBinary: Bool
+    let added: Int
+    let removed: Int
+    let mainContent: String?
+    let worktreeContent: String?
+    let lines: [DiffLine]
+
+    var id: String { path }
+
+    /// Classifies a copied file from raw bytes. `mainData == nil` ⇒ `.new`.
+    /// Non-UTF-8 on either side ⇒ binary (byte-compared, no line preview).
+    static func classify(path: String, mainData: Data?, worktreeData: Data) -> CopiedFile {
+        let worktreeText = String(data: worktreeData, encoding: .utf8)
+
+        guard let mainData else {
+            // New file — not in main.
+            if let worktreeText {
+                let lines = LineDiff.compute("", worktreeText)
+                return CopiedFile(path: path, status: .new, isBinary: false,
+                                  added: lines.count, removed: 0,
+                                  mainContent: nil, worktreeContent: worktreeText, lines: lines)
+            }
+            return CopiedFile(path: path, status: .new, isBinary: true,
+                              added: 0, removed: 0,
+                              mainContent: nil, worktreeContent: nil, lines: [])
+        }
+
+        let mainText = String(data: mainData, encoding: .utf8)
+        let isBinary = (mainText == nil) || (worktreeText == nil)
+
+        if mainData == worktreeData {
+            return CopiedFile(path: path, status: .identical, isBinary: isBinary,
+                              added: 0, removed: 0,
+                              mainContent: mainText, worktreeContent: worktreeText, lines: [])
+        }
+
+        guard !isBinary, let mainText, let worktreeText else {
+            return CopiedFile(path: path, status: .modified, isBinary: true,
+                              added: 0, removed: 0,
+                              mainContent: mainText, worktreeContent: worktreeText, lines: [])
+        }
+
+        let lines = LineDiff.compute(mainText, worktreeText)
+        return CopiedFile(
+            path: path, status: .modified, isBinary: false,
+            added: lines.filter { $0.kind == .add }.count,
+            removed: lines.filter { $0.kind == .del }.count,
+            mainContent: mainText, worktreeContent: worktreeText, lines: lines
+        )
+    }
+}

--- a/OhMyWorktree/Models/LineDiff.swift
+++ b/OhMyWorktree/Models/LineDiff.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One line of a unified diff between two text blobs.
+struct DiffLine: Equatable, Sendable, Identifiable {
+    enum Kind: Equatable, Sendable { case context, add, del }
+    let kind: Kind
+    let text: String
+    /// 1-based line number on the "main" (a) side; nil for added lines.
+    let lineA: Int?
+    /// 1-based line number on the "worktree" (b) side; nil for deleted lines.
+    let lineB: Int?
+    /// Stable index assigned at build time (array position).
+    let id: Int
+}
+
+/// Minimal LCS line diff (port of the prototype's `data.jsx#diffLines`).
+enum LineDiff {
+
+    /// Compares `a` (main) against `b` (worktree), line by line.
+    /// An empty `a` yields all-adds; an empty `b` yields all-dels.
+    static func compute(_ a: String, _ b: String) -> [DiffLine] {
+        let aLines = a.components(separatedBy: "\n")
+        let bLines = b.components(separatedBy: "\n")
+
+        let rows: [Row]
+        if a.isEmpty {
+            rows = bLines.enumerated().map { Row(kind: .add, text: $0.element, lineA: nil, lineB: $0.offset + 1) }
+        } else if b.isEmpty {
+            rows = aLines.enumerated().map { Row(kind: .del, text: $0.element, lineA: $0.offset + 1, lineB: nil) }
+        } else {
+            rows = reconstruct(aLines, bLines, lcs: lcsLengths(aLines, bLines))
+        }
+
+        return rows.enumerated().map { index, row in
+            DiffLine(kind: row.kind, text: row.text, lineA: row.lineA, lineB: row.lineB, id: index)
+        }
+    }
+
+    private struct Row {
+        let kind: DiffLine.Kind
+        let text: String
+        let lineA: Int?
+        let lineB: Int?
+    }
+
+    /// `dp[i][j]` = LCS length of `aLines[i...]` and `bLines[j...]`.
+    private static func lcsLengths(_ aLines: [String], _ bLines: [String]) -> [[Int]] {
+        let n = aLines.count, m = bLines.count
+        var dp = Array(repeating: Array(repeating: 0, count: m + 1), count: n + 1)
+        for i in stride(from: n - 1, through: 0, by: -1) {
+            for j in stride(from: m - 1, through: 0, by: -1) {
+                dp[i][j] = aLines[i] == bLines[j] ? dp[i + 1][j + 1] + 1 : max(dp[i + 1][j], dp[i][j + 1])
+            }
+        }
+        return dp
+    }
+
+    /// Walks the LCS table to produce context/add/del rows.
+    private static func reconstruct(_ aLines: [String], _ bLines: [String], lcs dp: [[Int]]) -> [Row] {
+        let n = aLines.count, m = bLines.count
+        var rows: [Row] = []
+        var i = 0, j = 0
+        while i < n && j < m {
+            if aLines[i] == bLines[j] {
+                rows.append(Row(kind: .context, text: aLines[i], lineA: i + 1, lineB: j + 1)); i += 1; j += 1
+            } else if dp[i + 1][j] >= dp[i][j + 1] {
+                rows.append(Row(kind: .del, text: aLines[i], lineA: i + 1, lineB: nil)); i += 1
+            } else {
+                rows.append(Row(kind: .add, text: bLines[j], lineA: nil, lineB: j + 1)); j += 1
+            }
+        }
+        while i < n { rows.append(Row(kind: .del, text: aLines[i], lineA: i + 1, lineB: nil)); i += 1 }
+        while j < m { rows.append(Row(kind: .add, text: bLines[j], lineA: nil, lineB: j + 1)); j += 1 }
+        return rows
+    }
+}

--- a/OhMyWorktree/Models/WorktreeDetail.swift
+++ b/OhMyWorktree/Models/WorktreeDetail.swift
@@ -30,8 +30,9 @@ struct WorktreeDetail: Equatable, Sendable {
     var aheadBehind: AheadBehind?
     var diff: DiffStat
     var commits: [Commit]
-    /// Files copied into the worktree per `.worktreeinclude` (or `.env*`).
-    var copiedFiles: [String] = []
+    /// Files copied into the worktree per `.worktreeinclude` (or `.env*`),
+    /// each classified against main (the repository copy) for diff display.
+    var copiedFiles: [CopiedFile] = []
 
     static let empty = WorktreeDetail(
         aheadBehind: nil,

--- a/OhMyWorktree/Services/CopiedFileDiffer.swift
+++ b/OhMyWorktree/Services/CopiedFileDiffer.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Compares a worktree's copied (`.worktreeinclude`) files against the
+/// repository's (main worktree's) copies, and applies a worktree copy back to main.
+/// Stateless; safe to instantiate per call.
+final class CopiedFileDiffer: Sendable {
+
+    /// Builds a `CopiedFile` per relative path by reading both copies.
+    /// Paths absent in the worktree are skipped (the list is derived from a
+    /// worktree scan, so this is defensive). Result is sorted changed → new → identical.
+    func compare(relativePaths: [String], worktreePath: String, repositoryPath: String) -> [CopiedFile] {
+        let fm = FileManager.default
+        let files: [CopiedFile] = relativePaths.compactMap { rel in
+            let worktreeFull = (worktreePath as NSString).appendingPathComponent(rel)
+            guard let worktreeData = fm.contents(atPath: worktreeFull) else { return nil }
+            let mainFull = (repositoryPath as NSString).appendingPathComponent(rel)
+            let mainData = fm.contents(atPath: mainFull)
+            return CopiedFile.classify(path: rel, mainData: mainData, worktreeData: worktreeData)
+        }
+        return files.sorted { lhs, rhs in
+            lhs.status.sortRank != rhs.status.sortRank
+                ? lhs.status.sortRank < rhs.status.sortRank
+                : lhs.path < rhs.path
+        }
+    }
+
+    /// Overwrites main's local copy of `file` with the worktree's bytes (atomically;
+    /// creates the file and parent directories when absent). Never touches Git.
+    func applyToMain(_ file: CopiedFile, worktreePath: String, repositoryPath: String) throws {
+        let fm = FileManager.default
+        let source = URL(fileURLWithPath: (worktreePath as NSString).appendingPathComponent(file.path))
+        let dest = URL(fileURLWithPath: (repositoryPath as NSString).appendingPathComponent(file.path))
+        let destDir = (dest.path as NSString).deletingLastPathComponent
+        try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true)
+        let data = try Data(contentsOf: source)
+        try data.write(to: dest, options: .atomic)
+    }
+}

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
@@ -35,7 +35,7 @@ extension WorktreeListViewModel {
             try await Task.detached {
                 try differ.applyToMain(file, worktreePath: worktreePath, repositoryPath: repoPath)
             }.value
-            await loadDetail(for: worktree)
+            await loadDetail(for: worktree, clearingFirst: false)
             copiedBrowser?.focusedPath = nil
             copiedToast = "Applied \((file.path as NSString).lastPathComponent) to main"
         } catch {

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+// MARK: - Copied-files browser + apply-to-main glue
+//
+// Thin view-model glue: opening/closing the browser, drilling into a file, and
+// applying a copy back to main. The real work (diff + atomic write) lives in the
+// tested `CopiedFileDiffer`; this layer only coordinates state and reloads detail.
+
+extension WorktreeListViewModel {
+
+    /// Open state for the copied-files browser sheet.
+    struct CopiedBrowserState: Equatable {
+        var worktree: Worktree
+        var focusedPath: String?
+    }
+
+    /// Opens the browser to the full list for `worktree`.
+    func browseCopiedFiles(for worktree: Worktree) {
+        copiedBrowser = CopiedBrowserState(worktree: worktree, focusedPath: nil)
+    }
+
+    /// Opens the browser straight to `file`'s diff for `worktree`.
+    func openCopiedDiff(_ file: CopiedFile, for worktree: Worktree) {
+        copiedBrowser = CopiedBrowserState(worktree: worktree, focusedPath: file.path)
+    }
+
+    /// Applies `file` (worktree → main), reloads the detail so statuses refresh,
+    /// and shows a toast. Surfaces failures through the standard error alert.
+    func applyCopiedFileToMain(_ file: CopiedFile, in worktree: Worktree) async {
+        guard let repository else { return }
+        let differ = self.differ
+        let worktreePath = worktree.path
+        let repoPath = repository.path
+        do {
+            try await Task.detached {
+                try differ.applyToMain(file, worktreePath: worktreePath, repositoryPath: repoPath)
+            }.value
+            await loadDetail(for: worktree)
+            copiedToast = "Applied \((file.path as NSString).lastPathComponent) to main"
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
@@ -36,6 +36,7 @@ extension WorktreeListViewModel {
                 try differ.applyToMain(file, worktreePath: worktreePath, repositoryPath: repoPath)
             }.value
             await loadDetail(for: worktree)
+            copiedBrowser?.focusedPath = nil
             copiedToast = "Applied \((file.path as NSString).lastPathComponent) to main"
         } catch {
             errorMessage = error.localizedDescription

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
@@ -96,11 +96,16 @@ extension WorktreeListViewModel {
             repositoryPath: repository.path
         )
         let copier = fileCopier
+        let differ = self.differ
         let path = worktree.path
+        let repoPath = repository.path
         let matches = await Task.detached { copier.includedFiles(in: path) }.value
         // Only files Git ignores were actually copied; committed templates
         // (e.g. .env.example) come with the checkout and don't count.
-        detail.copiedFiles = await worktreeManager.gitIgnoredFiles(matches, worktreePath: path)
+        let ignored = await worktreeManager.gitIgnoredFiles(matches, worktreePath: path)
+        detail.copiedFiles = await Task.detached {
+            differ.compare(relativePaths: ignored, worktreePath: path, repositoryPath: repoPath)
+        }.value
         guard !Task.isCancelled else { return }
         selectedWorktreeDetail = detail
     }

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
@@ -85,12 +85,14 @@ extension WorktreeListViewModel {
 
     /// Loads ahead/behind, diff stat, and recent commits for the given worktree.
     /// Drive from a SwiftUI `.task(id:)` so it cancels and reloads on reselection.
-    func loadDetail(for worktree: Worktree?) async {
+    /// Pass `clearingFirst: false` for a same-worktree refresh (list reload,
+    /// post-apply) so the pane keeps its current data while recomputing.
+    func loadDetail(for worktree: Worktree?, clearingFirst: Bool = true) async {
         guard let worktree, let repository else {
             selectedWorktreeDetail = nil
             return
         }
-        selectedWorktreeDetail = nil
+        if clearingFirst { selectedWorktreeDetail = nil }
         var detail = await worktreeManager.worktreeDetail(
             worktreePath: worktree.path,
             repositoryPath: repository.path

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -172,6 +172,10 @@ final class WorktreeListViewModel {
 
         if debounce, let last = lastLoadTime,
            Date().timeIntervalSince(last) < Self.debounceInterval {
+            // The list is fresh enough to skip, but this is the app-activation /
+            // menu-open path — the selected worktree's files may have just been
+            // edited externally, so still refresh its detail in place.
+            await loadDetail(for: selectedWorktree, clearingFirst: false)
             return
         }
 

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -29,6 +29,14 @@ final class WorktreeListViewModel {
     /// Ahead/behind, diff stat, and recent commits for the currently selected worktree.
     var selectedWorktreeDetail: WorktreeDetail?
 
+    /// When non-nil, the copied-files browser sheet is open. `focusedPath`, when
+    /// set, opens straight to that file's diff (drill-in); nil shows the list.
+    var copiedBrowser: CopiedBrowserState?
+    /// A copied file awaiting Apply-to-main confirmation.
+    var pendingApply: CopiedFile?
+    /// Transient success message shown as a toast after an apply.
+    var copiedToast: String?
+
     // FR-032: Multi-select (native ⌘+click / ⇧+click via SwiftUI List)
     var selectedWorktreeIDs: Set<UUID> = [] {
         didSet {

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -200,6 +200,11 @@ final class WorktreeListViewModel {
                 self.lastLoadTime = Date()
                 self.updateSelectedWorktree(from: freshWorktrees)
                 self.schedulePRFetch(repositoryPath: repository.path)
+                // Detail (copied-file diffs, ahead/behind, commits) otherwise only
+                // recomputes on selection change — refresh it in place so file
+                // edits are picked up by every list-refresh trigger (activation,
+                // ⌘R, toolbar, menu).
+                await self.loadDetail(for: self.selectedWorktree, clearingFirst: false)
             } catch {
                 if !Task.isCancelled {
                     self.errorMessage = error.localizedDescription

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -66,6 +66,7 @@ final class WorktreeListViewModel {
     let store: RepositoryStore
     // internal for WorktreeListViewModel+Creation extension
     let fileCopier: WorktreeFileCopier
+    let differ: CopiedFileDiffer
     private let pullRequestService: PullRequestFetching
     @ObservationIgnored private var loadTask: Task<Void, Never>?
     @ObservationIgnored private var prFetchTask: Task<Void, Never>?
@@ -88,12 +89,14 @@ final class WorktreeListViewModel {
         toolLauncher: ExternalToolLauncher = ExternalToolLauncher(),
         store: RepositoryStore = .shared,
         fileCopier: WorktreeFileCopier = WorktreeFileCopier(),
+        differ: CopiedFileDiffer = CopiedFileDiffer(),
         pullRequestService: PullRequestFetching = PullRequestService()
     ) {
         self.worktreeManager = worktreeManager
         self.toolLauncher = toolLauncher
         self.store = store
         self.fileCopier = fileCopier
+        self.differ = differ
         self.pullRequestService = pullRequestService
         self.jobQueue = BackgroundTaskQueue(worktreeManager: worktreeManager, store: store)
 

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
             modalOverlay
         }
         .tint(accent)
+        .copiedFilesPresentation(worktreeViewModel)
         .environment(\.omwAccent, accent)
         .frame(minWidth: 860, minHeight: 520)
         .background(OMWColor.bgWindow)
@@ -157,6 +158,12 @@ struct ContentView: View {
             width: CGFloat(detailWidth),
             onOpenPR: {
                 if let wt = selectedWorktree { worktreeViewModel.openPullRequest(for: wt) }
+            },
+            onOpenCopiedDiff: { file in
+                if let wt = selectedWorktree { worktreeViewModel.openCopiedDiff(file, for: wt) }
+            },
+            onBrowseCopied: {
+                if let wt = selectedWorktree { worktreeViewModel.browseCopiedFiles(for: wt) }
             }
         )
     }
@@ -248,6 +255,20 @@ struct ContentView: View {
                     onDismiss: { worktreeViewModel.isShowingImportPR = false }
                 )
                 .environment(\.omwAccent, accent)
+            }
+        } else if let browser = worktreeViewModel.copiedBrowser {
+            glassModal {
+                CopiedFilesBrowser(
+                    files: worktreeViewModel.selectedWorktreeDetail?.copiedFiles ?? [],
+                    focusedPath: Binding(
+                        get: { worktreeViewModel.copiedBrowser?.focusedPath },
+                        set: { worktreeViewModel.copiedBrowser?.focusedPath = $0 }
+                    ),
+                    onApply: { file in worktreeViewModel.pendingApply = file },
+                    onClose: { worktreeViewModel.copiedBrowser = nil }
+                )
+                .environment(\.omwAccent, accent)
+                .id(browser.worktree.id)
             }
         }
     }

--- a/OhMyWorktree/Views/Detail/CopiedFileRow.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFileRow.swift
@@ -5,14 +5,17 @@ struct CopiedFileRow: View {
     let file: CopiedFile
     var onSelect: () -> Void
 
+    // Identical rows dim via color tier only and render as a non-button: a whole-row
+    // opacity multiplied the already-tertiary directory/dot colors (plus the
+    // disabled-button dim) into illegibility in light mode.
+    @ViewBuilder
     var body: some View {
-        let clickable = file.status.isClickable
-        Button { onSelect() } label: {
+        if file.status.isClickable {
+            Button { onSelect() } label: { rowContent }
+                .buttonStyle(.plain)
+        } else {
             rowContent
         }
-        .buttonStyle(.plain)
-        .disabled(!clickable)
-        .opacity(clickable ? 1 : 0.55)
     }
 
     private var rowContent: some View {
@@ -20,7 +23,7 @@ struct CopiedFileRow: View {
             Circle().fill(dotColor).frame(width: 7, height: 7)
             PathLabel(path: file.path)
                 .font(.omwMono(12.5, weight: .medium))
-                .foregroundStyle(OMWColor.labelPrimary)
+                .foregroundStyle(file.status.isClickable ? OMWColor.labelPrimary : OMWColor.labelSecondary)
             Spacer(minLength: 8)
             rowBadge
             if file.status.isClickable {
@@ -57,7 +60,7 @@ struct CopiedFileRow: View {
         switch file.status {
         case .modified: OMWColor.sysOrange
         case .new: OMWColor.sysGreen
-        case .identical: OMWColor.labelQuaternary
+        case .identical: OMWColor.labelTertiary
         }
     }
 }

--- a/OhMyWorktree/Views/Detail/CopiedFileRow.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFileRow.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// A full-width row in the browser list: status dot · path · `+N −N`/`new`/`identical` · chevron.
+struct CopiedFileRow: View {
+    let file: CopiedFile
+    var onSelect: () -> Void
+
+    var body: some View {
+        let clickable = file.status.isClickable
+        Button { if clickable { onSelect() } } label: {
+            rowContent
+        }
+        .buttonStyle(.plain)
+        .disabled(!clickable)
+        .opacity(clickable ? 1 : 0.55)
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 9) {
+            Circle().fill(dotColor).frame(width: 7, height: 7)
+            PathLabel(path: file.path)
+                .font(.omwMono(12.5, weight: .medium))
+                .foregroundStyle(OMWColor.labelPrimary)
+            Spacer(minLength: 8)
+            rowBadge
+            if file.status.isClickable {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OMWColor.labelTertiary)
+            }
+        }
+        .padding(.horizontal, 11).frame(height: 38)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(OMWColor.fillTertiary.opacity(0.0001))   // hit area
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var rowBadge: some View {
+        switch file.status {
+        case .modified:
+            HStack(spacing: 4) {
+                Text("+\(file.added)").foregroundStyle(OMWColor.sysGreen)
+                Text("−\(file.removed)").foregroundStyle(OMWColor.sysRed)
+            }
+            .font(.omwMono(12, weight: .bold))
+        case .new:
+            Text("new").font(.system(size: 10, weight: .bold)).textCase(.uppercase)
+                .tracking(0.4).foregroundStyle(OMWColor.sysGreen)
+        case .identical:
+            Text("identical").font(.system(size: 10, weight: .medium))
+                .foregroundStyle(OMWColor.labelTertiary)
+        }
+    }
+
+    private var dotColor: Color {
+        switch file.status {
+        case .modified: OMWColor.sysOrange
+        case .new: OMWColor.sysGreen
+        case .identical: OMWColor.labelQuaternary
+        }
+    }
+}

--- a/OhMyWorktree/Views/Detail/CopiedFileRow.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFileRow.swift
@@ -7,7 +7,7 @@ struct CopiedFileRow: View {
 
     var body: some View {
         let clickable = file.status.isClickable
-        Button { if clickable { onSelect() } } label: {
+        Button { onSelect() } label: {
             rowContent
         }
         .buttonStyle(.plain)

--- a/OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// One glass sheet that browses a worktree's copied files and drills into a
+/// unified diff vs. main. `focusedPath` (re-resolved against `files` each render so
+/// it reflects applied changes) opens straight to that file's diff.
+struct CopiedFilesBrowser: View {
+    let files: [CopiedFile]
+    @Binding var focusedPath: String?
+    var onApply: (CopiedFile) -> Void
+    var onClose: () -> Void
+
+    @Environment(\.omwAccent) private var accent
+    @State private var query = ""
+    @State private var changedOnly = false
+
+    private var changedCount: Int { files.filter { $0.status.isChanged }.count }
+
+    private var active: CopiedFile? {
+        guard let focusedPath else { return nil }
+        return files.first { $0.path == focusedPath }
+    }
+
+    private var sorted: [CopiedFile] {
+        files.sorted { lhs, rhs in
+            lhs.status.sortRank != rhs.status.sortRank
+                ? lhs.status.sortRank < rhs.status.sortRank
+                : lhs.path < rhs.path
+        }
+    }
+
+    private var filtered: [CopiedFile] {
+        sorted.filter { file in
+            (!changedOnly || file.status.isChanged)
+                && (query.isEmpty || file.path.lowercased().contains(query.lowercased()))
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let active {
+                diffView(active)
+            } else {
+                listView
+            }
+        }
+        .frame(width: 520)
+        .frame(maxHeight: 560)
+        .glassSheet()
+        .tint(accent)
+        .onExitCommand {
+            if focusedPath != nil {
+                focusedPath = nil
+            } else {
+                onClose()
+            }
+        }
+    }
+
+    // MARK: List
+
+    private var listView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            listHeader
+                .padding(.init(top: 16, leading: 18, bottom: 0, trailing: 18))
+            listControls
+                .padding(.init(top: 12, leading: 18, bottom: 4, trailing: 18))
+            fileList
+            footer(hint: "Click a changed file to view its diff and apply it back to main.") {
+                Button("Done", action: onClose)
+                    .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    private var listHeader: some View {
+        HStack(alignment: .firstTextBaseline) {
+            HStack(spacing: 7) {
+                Text("Copied files").font(.system(size: 14, weight: .bold))
+                Text("\(files.count)").font(.system(size: 12, weight: .semibold)).foregroundStyle(OMWColor.labelTertiary)
+                if changedCount > 0 {
+                    Text("· \(changedCount) changed vs. main")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(OMWColor.sysOrange)
+                }
+            }
+            Spacer()
+            Text(".worktreeinclude").font(.omwMono(11)).foregroundStyle(OMWColor.labelQuaternary)
+        }
+    }
+
+    private var listControls: some View {
+        HStack(spacing: 9) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass").font(.system(size: 12)).foregroundStyle(OMWColor.labelTertiary)
+                TextField("Filter files…", text: $query).textFieldStyle(.plain).font(.system(size: 12))
+            }
+            .padding(.horizontal, 10).frame(height: 28)
+            .background(OMWColor.controlBg, in: Capsule())
+            .overlay(Capsule().strokeBorder(OMWColor.separator, lineWidth: 0.5))
+
+            if changedCount > 0 {
+                Button { changedOnly.toggle() } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: changedOnly ? "checkmark" : "arrow.left.arrow.right").font(.system(size: 12))
+                        Text("Changed only").font(.system(size: 11, weight: .semibold))
+                    }
+                    .foregroundStyle(changedOnly ? OMWColor.onAccent : OMWColor.labelSecondary)
+                    .padding(.horizontal, 11).frame(height: 28)
+                    .background(changedOnly ? AnyShapeStyle(accent) : AnyShapeStyle(OMWColor.fillTertiary), in: Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var fileList: some View {
+        ScrollView {
+            LazyVStack(spacing: 2) {
+                ForEach(filtered) { file in
+                    CopiedFileRow(file: file) { focusedPath = file.path }
+                }
+                if filtered.isEmpty {
+                    Text("No files match \u{201C}\(query)\u{201D}.")
+                        .font(.system(size: 13)).foregroundStyle(OMWColor.labelTertiary)
+                        .frame(maxWidth: .infinity).padding(.vertical, 26)
+                }
+            }
+            .padding(.init(top: 6, leading: 12, bottom: 12, trailing: 12))
+        }
+    }
+
+    // MARK: Diff drill-in
+
+    private func diffView(_ file: CopiedFile) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            diffHeader(file)
+            PathLabel(path: file.path)
+                .font(.omwMono(14, weight: .bold))
+                .foregroundStyle(OMWColor.labelPrimary)
+                .padding(.init(top: 8, leading: 18, bottom: 0, trailing: 18))
+            UnifiedDiffView(file: file)
+                .padding(.init(top: 12, leading: 18, bottom: 4, trailing: 18))
+            footer(hint: "Updates main's local copy only — nothing is committed to Git.") {
+                Button { onApply(file) } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.left.to.line").font(.system(size: 13))
+                        Text(file.status == .new ? "Copy to main" : "Apply to main")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                }
+                .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
+            }
+        }
+    }
+
+    private func diffHeader(_ file: CopiedFile) -> some View {
+        HStack {
+            Button { focusedPath = nil } label: {
+                HStack(spacing: 2) {
+                    Image(systemName: "chevron.left").font(.system(size: 13, weight: .semibold))
+                    Text("All files").font(.system(size: 12.5, weight: .semibold))
+                }
+                .foregroundStyle(accent)
+                .padding(.init(top: 4, leading: 4, bottom: 4, trailing: 8))
+            }
+            .buttonStyle(.plain)
+            Spacer()
+            Text(file.status == .new ? "new file — not in main" : "comparing vs. main")
+                .font(.omwMono(11)).foregroundStyle(OMWColor.labelQuaternary)
+        }
+        .padding(.init(top: 12, leading: 14, bottom: 0, trailing: 14))
+    }
+
+    // MARK: Footer
+
+    private func footer(hint: String, @ViewBuilder trailing: () -> some View) -> some View {
+        HStack(spacing: 14) {
+            Text(hint).font(.system(size: 11)).foregroundStyle(OMWColor.labelTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+            trailing()
+        }
+        .padding(.init(top: 12, leading: 18, bottom: 14, trailing: 18))
+        .overlay(alignment: .top) { Rectangle().fill(OMWColor.separator).frame(height: 0.5) }
+    }
+}

--- a/OhMyWorktree/Views/Detail/CopiedFilesPresentation.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesPresentation.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+extension View {
+    /// Adds the copied-files success toast + the apply-to-main confirmation alert.
+    /// Extracted from ContentView to keep that file under the length limit.
+    func copiedFilesPresentation(_ viewModel: WorktreeListViewModel) -> some View {
+        modifier(CopiedFilesPresentation(viewModel: viewModel))
+    }
+}
+
+private struct CopiedFilesPresentation: ViewModifier {
+    var viewModel: WorktreeListViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                CopiedToast(message: Binding(
+                    get: { viewModel.copiedToast },
+                    set: { viewModel.copiedToast = $0 }
+                ))
+            }
+            .alert(
+                viewModel.pendingApply.map { "Apply \(($0.path as NSString).lastPathComponent) to main?" } ?? "",
+                isPresented: Binding(
+                    get: { viewModel.pendingApply != nil },
+                    set: { if !$0 { viewModel.pendingApply = nil } }
+                ),
+                presenting: viewModel.pendingApply
+            ) { file in
+                Button(file.status == .new ? "Copy to main" : "Apply to main", role: .destructive) {
+                    let target = viewModel.copiedBrowser?.worktree
+                    viewModel.pendingApply = nil
+                    if let target {
+                        Task { await viewModel.applyCopiedFileToMain(file, in: target) }
+                    }
+                }
+                Button("Cancel", role: .cancel) { viewModel.pendingApply = nil }
+            } message: { file in
+                Text("Overwrites main's local copy of \(file.path) with this worktree's version. "
+                    + "This updates the file on disk only — nothing is committed to Git.")
+            }
+    }
+}

--- a/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
@@ -62,7 +62,7 @@ struct CopiedFilesSection: View {
     @ViewBuilder
     private func chip(_ file: CopiedFile) -> some View {
         let clickable = file.status.isClickable
-        Button { if clickable { onOpenDiff(file) } } label: {
+        Button { onOpenDiff(file) } label: {
             HStack(spacing: 5) {
                 switch file.status {
                 case .modified: Circle().fill(OMWColor.sysOrange).frame(width: 6, height: 6)
@@ -85,7 +85,7 @@ struct CopiedFilesSection: View {
                         .foregroundStyle(OMWColor.sysGreen)
                 }
             }
-            .foregroundStyle(file.status == .identical ? OMWColor.labelSecondary : OMWColor.labelPrimary)
+            .foregroundStyle(OMWColor.labelPrimary)
             .padding(.horizontal, 9)
             .frame(height: 22)
             .background(chipBackground(file.status), in: Capsule())

--- a/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Detail-pane "Copied files" section: collapses to the first few chips with a
 /// "+N more" affordance; expands to a scrollable list with a filter when large.
 struct CopiedFilesSection: View {
-    let files: [String]
+    let files: [CopiedFile]
 
     @State private var expanded = false
     @State private var query = ""
@@ -13,10 +13,11 @@ struct CopiedFilesSection: View {
     var body: some View {
         let many = files.count > cap
         let searchable = files.count > 12
+        let names = files.map(\.path)
         let filtered = query.isEmpty
-            ? files
-            : files.filter { $0.lowercased().contains(query.lowercased()) }
-        let shown = (!expanded && many) ? Array(files.prefix(cap)) : filtered
+            ? names
+            : names.filter { $0.lowercased().contains(query.lowercased()) }
+        let shown = (!expanded && many) ? Array(names.prefix(cap)) : filtered
 
         VStack(alignment: .leading, spacing: 10) {
             header

--- a/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
@@ -59,41 +59,48 @@ struct CopiedFilesSection: View {
         }
     }
 
+    // Identical chips dim via color tier only (secondary text on a plain fill) and
+    // render as a non-button: stacking a whole-chip opacity on the already-tertiary
+    // directory text (plus the disabled-button dim) made them illegible in light mode.
     @ViewBuilder
     private func chip(_ file: CopiedFile) -> some View {
-        let clickable = file.status.isClickable
-        Button { onOpenDiff(file) } label: {
-            HStack(spacing: 5) {
-                switch file.status {
-                case .modified: Circle().fill(OMWColor.sysOrange).frame(width: 6, height: 6)
-                case .new: Circle().fill(OMWColor.sysGreen).frame(width: 6, height: 6)
-                case .identical: Image(systemName: "doc").font(.system(size: 11))
-                }
-                PathLabel(path: file.path)
-                    .font(.omwMono(11, weight: .medium))
-                if file.status == .modified {
-                    HStack(spacing: 4) {
-                        Text("+\(file.added)").foregroundStyle(OMWColor.sysGreen)
-                        Text("−\(file.removed)").foregroundStyle(OMWColor.sysRed)
-                    }
-                    .font(.omwMono(11, weight: .bold))
-                } else if file.status == .new {
-                    Text("new")
-                        .font(.system(size: 9, weight: .bold))
-                        .textCase(.uppercase)
-                        .tracking(0.4)
-                        .foregroundStyle(OMWColor.sysGreen)
-                }
-            }
-            .foregroundStyle(OMWColor.labelPrimary)
-            .padding(.horizontal, 9)
-            .frame(height: 22)
-            .background(chipBackground(file.status), in: Capsule())
-            .opacity(file.status == .identical ? 0.48 : 1)
+        if file.status.isClickable {
+            Button { onOpenDiff(file) } label: { chipLabel(file) }
+                .buttonStyle(.plain)
+                .help("\(file.path) — click to compare with main")
+        } else {
+            chipLabel(file)
+                .help("\(file.path) — identical to main")
         }
-        .buttonStyle(.plain)
-        .disabled(!clickable)
-        .help(clickable ? "\(file.path) — click to compare with main" : "\(file.path) — identical to main")
+    }
+
+    private func chipLabel(_ file: CopiedFile) -> some View {
+        HStack(spacing: 5) {
+            switch file.status {
+            case .modified: Circle().fill(OMWColor.sysOrange).frame(width: 6, height: 6)
+            case .new: Circle().fill(OMWColor.sysGreen).frame(width: 6, height: 6)
+            case .identical: Image(systemName: "doc").font(.system(size: 11))
+            }
+            PathLabel(path: file.path)
+                .font(.omwMono(11, weight: .medium))
+            if file.status == .modified {
+                HStack(spacing: 4) {
+                    Text("+\(file.added)").foregroundStyle(OMWColor.sysGreen)
+                    Text("−\(file.removed)").foregroundStyle(OMWColor.sysRed)
+                }
+                .font(.omwMono(11, weight: .bold))
+            } else if file.status == .new {
+                Text("new")
+                    .font(.system(size: 9, weight: .bold))
+                    .textCase(.uppercase)
+                    .tracking(0.4)
+                    .foregroundStyle(OMWColor.sysGreen)
+            }
+        }
+        .foregroundStyle(file.status == .identical ? OMWColor.labelSecondary : OMWColor.labelPrimary)
+        .padding(.horizontal, 9)
+        .frame(height: 22)
+        .background(chipBackground(file.status), in: Capsule())
     }
 
     private func chipBackground(_ status: CopiedFileStatus) -> Color {

--- a/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
@@ -1,29 +1,34 @@
 import SwiftUI
 
-/// Detail-pane "Copied files" section: collapses to the first few chips with a
-/// "+N more" affordance; expands to a scrollable list with a filter when large.
+/// Detail-pane "Copied files" section: a compact one-line header with a changed
+/// count, status chips (modified `+N −N` / `new` / dimmed identical), and a
+/// "View all" button that opens the searchable browser sheet.
 struct CopiedFilesSection: View {
     let files: [CopiedFile]
-
-    @State private var expanded = false
-    @State private var query = ""
+    var onOpenDiff: (CopiedFile) -> Void = { _ in }
+    var onBrowseAll: () -> Void = {}
 
     private let cap = 5
 
+    private var sorted: [CopiedFile] {
+        files.sorted { lhs, rhs in
+            lhs.status.sortRank != rhs.status.sortRank
+                ? lhs.status.sortRank < rhs.status.sortRank
+                : lhs.path < rhs.path
+        }
+    }
+    private var changedCount: Int { files.filter { $0.status.isChanged }.count }
+
     var body: some View {
         let many = files.count > cap
-        let searchable = files.count > 12
-        let names = files.map(\.path)
-        let filtered = query.isEmpty
-            ? names
-            : names.filter { $0.lowercased().contains(query.lowercased()) }
-        let shown = (!expanded && many) ? Array(names.prefix(cap)) : filtered
+        let shown = many ? Array(sorted.prefix(cap)) : sorted
 
         VStack(alignment: .leading, spacing: 10) {
             header
-            if expanded && searchable { searchField }
-            chips(shown: shown, many: many, noMatches: expanded && !query.isEmpty && filtered.isEmpty)
-            if expanded && many { showLessButton }
+            FlowLayout(spacing: 6) {
+                ForEach(shown) { chip($0) }
+            }
+            if many { viewAllButton }
         }
         .padding(.init(top: 14, leading: 18, bottom: 14, trailing: 18))
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -37,10 +42,16 @@ struct CopiedFilesSection: View {
                     .font(.system(size: 11, weight: .bold))
                     .textCase(.uppercase)
                     .tracking(0.3)
+                    .foregroundStyle(OMWColor.labelTertiary)
                 Text("\(files.count)")
                     .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(OMWColor.labelTertiary)
+                if changedCount > 0 {
+                    Text("· \(changedCount) changed")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(OMWColor.sysOrange)
+                }
             }
-            .foregroundStyle(OMWColor.labelTertiary)
             Spacer()
             Text(".worktreeinclude")
                 .font(.omwMono(10))
@@ -48,65 +59,64 @@ struct CopiedFilesSection: View {
         }
     }
 
-    private var searchField: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "magnifyingglass").font(.system(size: 12)).foregroundStyle(OMWColor.labelTertiary)
-            TextField("Filter \(files.count) files…", text: $query)
-                .textFieldStyle(.plain)
-                .font(.system(size: 12))
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 28)
-        .background(OMWColor.controlBg, in: Capsule())
-        .overlay(Capsule().strokeBorder(OMWColor.separator, lineWidth: 0.5))
-    }
-
     @ViewBuilder
-    private func chips(shown: [String], many: Bool, noMatches: Bool) -> some View {
-        let flow = FlowLayout(spacing: 6) {
-            ForEach(shown, id: \.self) { CopiedFileChip(name: $0) }
-            if !expanded && many { moreButton }
-            if noMatches {
-                Text("No files match “\(query)”.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(OMWColor.labelTertiary)
+    private func chip(_ file: CopiedFile) -> some View {
+        let clickable = file.status.isClickable
+        Button { if clickable { onOpenDiff(file) } } label: {
+            HStack(spacing: 5) {
+                switch file.status {
+                case .modified: Circle().fill(OMWColor.sysOrange).frame(width: 6, height: 6)
+                case .new: Circle().fill(OMWColor.sysGreen).frame(width: 6, height: 6)
+                case .identical: Image(systemName: "doc").font(.system(size: 11))
+                }
+                PathLabel(path: file.path)
+                    .font(.omwMono(11, weight: .medium))
+                if file.status == .modified {
+                    HStack(spacing: 4) {
+                        Text("+\(file.added)").foregroundStyle(OMWColor.sysGreen)
+                        Text("−\(file.removed)").foregroundStyle(OMWColor.sysRed)
+                    }
+                    .font(.omwMono(11, weight: .bold))
+                } else if file.status == .new {
+                    Text("new")
+                        .font(.system(size: 9, weight: .bold))
+                        .textCase(.uppercase)
+                        .tracking(0.4)
+                        .foregroundStyle(OMWColor.sysGreen)
+                }
             }
-        }
-        if expanded && many {
-            ScrollView {
-                flow.frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxHeight: 156)
-        } else {
-            flow
-        }
-    }
-
-    private var moreButton: some View {
-        Button { expanded = true } label: {
-            Text("+\(files.count - cap) more")
-                .font(.omwMono(11, weight: .semibold))
-                .foregroundStyle(OMWColor.labelSecondary)
-                .padding(.horizontal, 9)
-                .frame(height: 22)
-                .background(OMWColor.fillSecondary, in: Capsule())
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var showLessButton: some View {
-        Button {
-            expanded = false
-            query = ""
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "chevron.up").font(.system(size: 10, weight: .semibold))
-                Text("Show less").font(.system(size: 11, weight: .semibold))
-            }
-            .foregroundStyle(OMWColor.labelSecondary)
+            .foregroundStyle(file.status == .identical ? OMWColor.labelSecondary : OMWColor.labelPrimary)
             .padding(.horizontal, 9)
             .frame(height: 22)
-            .background(OMWColor.fillSecondary, in: Capsule())
+            .background(chipBackground(file.status), in: Capsule())
+            .opacity(file.status == .identical ? 0.48 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(!clickable)
+        .help(clickable ? "\(file.path) — click to compare with main" : "\(file.path) — identical to main")
+    }
+
+    private func chipBackground(_ status: CopiedFileStatus) -> Color {
+        switch status {
+        case .modified: OMWColor.sysOrange.opacity(0.15)
+        case .new: OMWColor.sysGreen.opacity(0.15)
+        case .identical: OMWColor.fillTertiary
+        }
+    }
+
+    private var viewAllButton: some View {
+        Button(action: onBrowseAll) {
+            HStack(spacing: 7) {
+                Image(systemName: "list.bullet").font(.system(size: 13))
+                Text("View all \(files.count) files").font(.system(size: 12, weight: .medium))
+                Spacer()
+                Image(systemName: "chevron.right").font(.system(size: 11)).foregroundStyle(OMWColor.labelTertiary)
+            }
+            .foregroundStyle(OMWColor.labelSecondary)
+            .padding(.horizontal, 11)
+            .frame(height: 30)
+            .frame(maxWidth: .infinity)
+            .background(OMWColor.fillTertiary, in: RoundedRectangle(cornerRadius: OMWRadius.md))
         }
         .buttonStyle(.plain)
     }

--- a/OhMyWorktree/Views/Detail/CopiedToast.swift
+++ b/OhMyWorktree/Views/Detail/CopiedToast.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// A transient success pill pinned near the bottom of the window. Auto-dismisses
+/// ~2.4s after `message` becomes non-nil by clearing the binding.
+struct CopiedToast: View {
+    @Binding var message: String?
+
+    var body: some View {
+        VStack {
+            Spacer()
+            if let message {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(OMWColor.sysGreen)
+                    Text(message).font(.system(size: 12, weight: .medium)).foregroundStyle(OMWColor.labelPrimary)
+                }
+                .padding(.horizontal, 14).padding(.vertical, 9)
+                .glassEffect(.regular, in: Capsule())
+                .shadow(color: .black.opacity(0.28), radius: 16, y: 8)
+                .padding(.bottom, 46)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .task(id: message) {
+                    // swiftlint:disable:next no_arbitrary_delay
+                    try? await Task.sleep(for: .seconds(2.4))
+                    self.message = nil
+                }
+            }
+        }
+        .animation(.spring(response: 0.34, dampingFraction: 0.86), value: message)
+        .allowsHitTesting(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/OhMyWorktree/Views/Detail/DetailPaneView.swift
+++ b/OhMyWorktree/Views/Detail/DetailPaneView.swift
@@ -18,6 +18,8 @@ struct DetailPaneView: View {
     var tools: [ActionTool]
     var width: CGFloat
     var onOpenPR: () -> Void
+    var onOpenCopiedDiff: (CopiedFile) -> Void = { _ in }
+    var onBrowseCopied: () -> Void = {}
 
     @Environment(\.omwAccent) private var accent
 
@@ -69,7 +71,7 @@ struct DetailPaneView: View {
                 section("Recent commits") { commitList(commits) }
             }
             if let copied = detail?.copiedFiles, !copied.isEmpty {
-                CopiedFilesSection(files: copied)
+                CopiedFilesSection(files: copied, onOpenDiff: onOpenCopiedDiff, onBrowseAll: onBrowseCopied)
             }
         }
     }

--- a/OhMyWorktree/Views/Detail/PathLabel.swift
+++ b/OhMyWorktree/Views/Detail/PathLabel.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Renders a repo-relative path so the directory truncates with an ellipsis while
+/// the filename is always fully visible. Full path shown on hover (CSS `.pl`).
+/// Font/size come from the caller (`.font(...)`); only the directory is recolored
+/// to tertiary — the filename inherits the surrounding foreground style.
+struct PathLabel: View {
+    let path: String
+
+    var body: some View {
+        let parts = CopiedPath.split(path)
+        HStack(spacing: 0) {
+            if !parts.dir.isEmpty {
+                Text(parts.dir)
+                    .foregroundStyle(OMWColor.labelTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .layoutPriority(0)
+            }
+            Text(parts.base)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(1)
+        }
+        .help(path)
+    }
+}

--- a/OhMyWorktree/Views/Detail/UnifiedDiffView.swift
+++ b/OhMyWorktree/Views/Detail/UnifiedDiffView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// GitHub-style unified diff: line-number gutters · +/− sign · code, red/green tinted.
+/// Binary files (no line preview) show a placeholder instead.
+struct UnifiedDiffView: View {
+    let file: CopiedFile
+
+    var body: some View {
+        if file.isBinary {
+            binaryPlaceholder
+        } else {
+            diffScroll
+        }
+    }
+
+    private var binaryPlaceholder: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "doc.badge.gearshape").font(.system(size: 13))
+            Text("Binary file — no preview").font(.system(size: 12, weight: .medium))
+        }
+        .foregroundStyle(OMWColor.labelTertiary)
+        .frame(maxWidth: .infinity).padding(.vertical, 36)
+        .background(OMWColor.fillQuaternary, in: RoundedRectangle(cornerRadius: OMWRadius.md))
+    }
+
+    private var diffScroll: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(file.lines) { line in row(line) }
+            }
+        }
+        .frame(maxHeight: 380)
+        .overlay(RoundedRectangle(cornerRadius: OMWRadius.md).strokeBorder(OMWColor.separator, lineWidth: 0.5))
+        .clipShape(RoundedRectangle(cornerRadius: OMWRadius.md))
+    }
+
+    private func row(_ line: DiffLine) -> some View {
+        HStack(spacing: 0) {
+            gutter(line.lineA)
+            gutter(line.lineB).overlay(alignment: .trailing) {
+                Rectangle().fill(OMWColor.separator).frame(width: 0.5)
+            }
+            Text(sign(line.kind)).frame(width: 16).foregroundStyle(signColor(line.kind))
+            Text(line.text.isEmpty ? " " : line.text)
+                .foregroundStyle(OMWColor.labelPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.trailing, 10).padding(.leading, 5)
+        }
+        .font(.omwMono(11))
+        .padding(.vertical, 1)
+        .background(rowBackground(line.kind))
+    }
+
+    private func gutter(_ number: Int?) -> some View {
+        Text(number.map(String.init) ?? "")
+            .font(.omwMono(10)).foregroundStyle(OMWColor.labelQuaternary)
+            .frame(width: 34, alignment: .trailing).padding(.trailing, 6)
+    }
+
+    private func sign(_ kind: DiffLine.Kind) -> String {
+        switch kind {
+        case .add: "+"
+        case .del: "−"
+        case .context: ""
+        }
+    }
+
+    private func signColor(_ kind: DiffLine.Kind) -> Color {
+        switch kind {
+        case .add: OMWColor.sysGreen
+        case .del: OMWColor.sysRed
+        case .context: OMWColor.labelTertiary
+        }
+    }
+
+    private func rowBackground(_ kind: DiffLine.Kind) -> Color {
+        switch kind {
+        case .add: OMWColor.sysGreen.opacity(0.13)
+        case .del: OMWColor.sysRed.opacity(0.12)
+        case .context: Color.clear
+        }
+    }
+}

--- a/OhMyWorktreeTests/CopiedFileDifferTests.swift
+++ b/OhMyWorktreeTests/CopiedFileDifferTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+final class CopiedFileDifferTests {
+
+    private let repoDir: String
+    private let worktreeDir: String
+    private let fm = FileManager.default
+    private let sut = CopiedFileDiffer()
+
+    init() {
+        let base = NSTemporaryDirectory() + "CopiedFileDifferTests-\(UUID().uuidString)"
+        repoDir = base + "/repo"
+        worktreeDir = base + "/worktree"
+        try! fm.createDirectory(atPath: repoDir, withIntermediateDirectories: true)
+        try! fm.createDirectory(atPath: worktreeDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        let base = (repoDir as NSString).deletingLastPathComponent
+        try? fm.removeItem(atPath: base)
+    }
+
+    private func write(_ rel: String, in dir: String, _ bytes: Data) {
+        let full = (dir as NSString).appendingPathComponent(rel)
+        try! fm.createDirectory(atPath: (full as NSString).deletingLastPathComponent,
+                                withIntermediateDirectories: true)
+        fm.createFile(atPath: full, contents: bytes)
+    }
+
+    private func write(_ rel: String, in dir: String, _ text: String) {
+        write(rel, in: dir, Data(text.utf8))
+    }
+
+    private func read(_ rel: String, in dir: String) -> Data? {
+        fm.contents(atPath: (dir as NSString).appendingPathComponent(rel))
+    }
+
+    // MARK: compare
+
+    @Test func compareClassifiesAndSorts() {
+        write("apps/a/.env", in: repoDir, "A=1")
+        write("apps/a/.env", in: worktreeDir, "A=2")       // modified
+        write("same.env", in: repoDir, "X=1")
+        write("same.env", in: worktreeDir, "X=1")          // identical
+        write("brand.env", in: worktreeDir, "N=1")         // new (only in worktree)
+
+        let files = sut.compare(relativePaths: ["same.env", "apps/a/.env", "brand.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        // sorted: modified(0) → new(1) → identical(2)
+        #expect(files.map(\.path) == ["apps/a/.env", "brand.env", "same.env"])
+        #expect(files.map(\.status) == [.modified, .new, .identical])
+    }
+
+    @Test func compareSkipsMissingWorktreeFile() {
+        write("ghost.env", in: repoDir, "A=1")   // exists in main, not in worktree
+        let files = sut.compare(relativePaths: ["ghost.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+        #expect(files.isEmpty)
+    }
+
+    @Test func compareDetectsBinaryModified() {
+        write("a.bin", in: repoDir, Data([0xFF, 0x00]))
+        write("a.bin", in: worktreeDir, Data([0xFF, 0x01]))
+        let files = sut.compare(relativePaths: ["a.bin"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+        #expect(files.first?.status == .modified)
+        #expect(files.first?.isBinary == true)
+    }
+
+    // MARK: applyToMain
+
+    @Test func applyOverwritesExistingMainCopy() throws {
+        write("apps/a/.env", in: repoDir, "A=1")
+        write("apps/a/.env", in: worktreeDir, "A=2\nB=3")
+        let file = sut.compare(relativePaths: ["apps/a/.env"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+
+        try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        #expect(read("apps/a/.env", in: repoDir) == Data("A=2\nB=3".utf8))
+        // re-comparing now reports identical
+        let after = sut.compare(relativePaths: ["apps/a/.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(after.status == .identical)
+    }
+
+    @Test func applyCopiesNewFileCreatingDirs() throws {
+        write("config/local/new.json", in: worktreeDir, "{}")
+        let file = sut.compare(relativePaths: ["config/local/new.json"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(file.status == .new)
+
+        try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        #expect(read("config/local/new.json", in: repoDir) == Data("{}".utf8))
+    }
+
+    @Test func applyThrowsWhenSourceMissing() {
+        let phantom = CopiedFile(path: "gone.env", status: .new, isBinary: false,
+                                 added: 0, removed: 0, mainContent: nil,
+                                 worktreeContent: nil, lines: [])
+        #expect(throws: (any Error).self) {
+            try sut.applyToMain(phantom, worktreePath: worktreeDir, repositoryPath: repoDir)
+        }
+    }
+
+    @Test func applyThrowsWhenDestDirBlockedByFile() {
+        // A *file* named "blocker" in repo blocks creating dir "blocker/".
+        write("blocker", in: repoDir, "x")
+        write("blocker/x.env", in: worktreeDir, "A=1")
+        let file = sut.compare(relativePaths: ["blocker/x.env"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(throws: (any Error).self) {
+            try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+        }
+    }
+}

--- a/OhMyWorktreeTests/CopiedFileTests.swift
+++ b/OhMyWorktreeTests/CopiedFileTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct CopiedFileTests {
+
+    private func data(_ s: String) -> Data { Data(s.utf8) }
+
+    // MARK: status flags
+
+    @Test func statusFlags() {
+        #expect(CopiedFileStatus.identical.isChanged == false)
+        #expect(CopiedFileStatus.modified.isChanged)
+        #expect(CopiedFileStatus.new.isChanged)
+        #expect(CopiedFileStatus.identical.isClickable == false)
+        #expect(CopiedFileStatus.modified.isClickable)
+        #expect(CopiedFileStatus.new.isClickable)
+        #expect(CopiedFileStatus.modified.sortRank < CopiedFileStatus.new.sortRank)
+        #expect(CopiedFileStatus.new.sortRank < CopiedFileStatus.identical.sortRank)
+    }
+
+    // MARK: path split
+
+    @Test func pathSplit() {
+        #expect(CopiedPath.split("apps/web/.env") == (dir: "apps/web/", base: ".env"))
+        #expect(CopiedPath.split(".env") == (dir: "", base: ".env"))
+        #expect(CopiedPath.split("a/") == (dir: "a/", base: ""))
+    }
+
+    // MARK: classify — text
+
+    @Test func classifyIdentical() {
+        let f = CopiedFile.classify(path: ".env", mainData: data("A=1"), worktreeData: data("A=1"))
+        #expect(f.status == .identical)
+        #expect(f.isBinary == false)
+        #expect(f.added == 0 && f.removed == 0)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func classifyModifiedCountsLines() {
+        let f = CopiedFile.classify(path: ".env",
+                                    mainData: data("A=1\nB=2"),
+                                    worktreeData: data("A=1\nB=3\nC=4"))
+        #expect(f.status == .modified)
+        #expect(f.isBinary == false)
+        #expect(f.added == 2)    // "B=3", "C=4"
+        #expect(f.removed == 1)  // "B=2"
+        #expect(f.lines.isEmpty == false)
+        #expect(f.mainContent == "A=1\nB=2")
+        #expect(f.worktreeContent == "A=1\nB=3\nC=4")
+    }
+
+    @Test func classifyNewIsAllAdds() {
+        let f = CopiedFile.classify(path: "new.env", mainData: nil, worktreeData: data("X=1\nY=2"))
+        #expect(f.status == .new)
+        #expect(f.isBinary == false)
+        #expect(f.added == 2 && f.removed == 0)
+        #expect(f.lines.map(\.kind) == [.add, .add])
+        #expect(f.mainContent == nil)
+    }
+
+    // MARK: classify — binary
+
+    @Test func classifyBinaryIdentical() {
+        let bytes = Data([0xFF, 0x00, 0xFE])
+        let f = CopiedFile.classify(path: "a.bin", mainData: bytes, worktreeData: bytes)
+        #expect(f.status == .identical)
+        #expect(f.isBinary)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func classifyBinaryModified() {
+        let f = CopiedFile.classify(path: "a.bin",
+                                    mainData: Data([0xFF, 0x00]),
+                                    worktreeData: Data([0xFF, 0x01]))
+        #expect(f.status == .modified)
+        #expect(f.isBinary)
+        #expect(f.added == 0 && f.removed == 0)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func classifyNewBinary() {
+        let f = CopiedFile.classify(path: "k.p12", mainData: nil, worktreeData: Data([0x00, 0xFF]))
+        #expect(f.status == .new)
+        #expect(f.isBinary)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func identifiableUsesPath() {
+        let f = CopiedFile.classify(path: "x/.env", mainData: data("a"), worktreeData: data("a"))
+        #expect(f.id == "x/.env")
+    }
+}

--- a/OhMyWorktreeTests/LineDiffTests.swift
+++ b/OhMyWorktreeTests/LineDiffTests.swift
@@ -1,0 +1,47 @@
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct LineDiffTests {
+
+    @Test func identicalIsAllContext() {
+        let rows = LineDiff.compute("a\nb\nc", "a\nb\nc")
+        #expect(rows.allSatisfy { $0.kind == .context })
+        #expect(rows.map(\.text) == ["a", "b", "c"])
+        #expect(rows.map(\.lineA) == [1, 2, 3])
+        #expect(rows.map(\.lineB) == [1, 2, 3])
+    }
+
+    @Test func emptyMainIsAllAdds() {
+        let rows = LineDiff.compute("", "x\ny")
+        #expect(rows.map(\.kind) == [.add, .add])
+        #expect(rows.map(\.lineA) == [nil, nil])
+        #expect(rows.map(\.lineB) == [1, 2])
+    }
+
+    @Test func emptyWorktreeIsAllDels() {
+        let rows = LineDiff.compute("x\ny", "")
+        #expect(rows.map(\.kind) == [.del, .del])
+        #expect(rows.map(\.lineB) == [nil, nil])
+        #expect(rows.map(\.lineA) == [1, 2])
+    }
+
+    @Test func singleLineChangeIsDelThenAdd() {
+        let rows = LineDiff.compute("a\nB\nc", "a\nb\nc")
+        #expect(rows.map(\.kind) == [.context, .del, .add, .context])
+        #expect(rows.filter { $0.kind == .add }.map(\.text) == ["b"])
+        #expect(rows.filter { $0.kind == .del }.map(\.text) == ["B"])
+    }
+
+    @Test func appendedLinesAreAdds() {
+        let rows = LineDiff.compute("a", "a\nb\nc")
+        #expect(rows.map(\.kind) == [.context, .add, .add])
+        #expect(rows.last?.lineB == 3)
+    }
+
+    @Test func idsAreUniqueAndSequential() {
+        let rows = LineDiff.compute("a\nB", "a\nb")
+        #expect(rows.map(\.id) == Array(0..<rows.count))
+    }
+}

--- a/OhMyWorktreeTests/WorktreeDetailTests.swift
+++ b/OhMyWorktreeTests/WorktreeDetailTests.swift
@@ -47,6 +47,18 @@ struct WorktreeDetailModelTests {
         #expect(WorktreeDetail.empty.commits.isEmpty)
         #expect(WorktreeDetail.empty.copiedFiles.isEmpty)
     }
+
+    @Test func copiedFilesHoldClassifiedEntries() {
+        let file = CopiedFile.classify(path: ".env",
+                                       mainData: Data("A=1".utf8),
+                                       worktreeData: Data("A=2".utf8))
+        let detail = WorktreeDetail(aheadBehind: nil,
+                                    diff: DiffStat(added: 0, removed: 0, files: 0),
+                                    commits: [],
+                                    copiedFiles: [file])
+        #expect(detail.copiedFiles.map(\.status) == [.modified])
+        #expect(detail.copiedFiles.first?.path == ".env")
+    }
 }
 
 // MARK: - Pure parser tests

--- a/OhMyWorktreeTests/WorktreeListViewModelDetailRefreshTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelDetailRefreshTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import OhMyWorktree
+
+// MARK: - Mock executor (porcelain list + check-ignore echo)
+
+/// Serves `worktree list --porcelain` from a fixture and echoes `check-ignore`
+/// candidates back (treats every copied file as git-ignored); everything else
+/// succeeds with empty output.
+private final class RefreshGitExecutor: GitCommandExecuting, @unchecked Sendable {
+    var worktreeListOutput = ""
+
+    func execute(command: String, arguments: [String], workingDirectory: String?) async throws -> CommandResult {
+        if arguments == ["worktree", "list", "--porcelain"] {
+            return CommandResult(stdout: worktreeListOutput, stderr: "", exitCode: 0)
+        }
+        if arguments.first == "check-ignore" {
+            let candidates = arguments.drop(while: { $0 != "--" }).dropFirst()
+            return CommandResult(stdout: candidates.joined(separator: "\n"), stderr: "", exitCode: 0)
+        }
+        return CommandResult(stdout: "", stderr: "", exitCode: 0)
+    }
+}
+
+// MARK: - Detail refresh on list reload
+
+/// Editing a copied file (e.g. `.env`) must be picked up by the refresh paths the
+/// app already has (activation, ⌘R, toolbar, menu) — all of which call
+/// `loadWorktrees`. The selected worktree's detail (copied-file diff statuses)
+/// must therefore refresh with the list, not only on selection change.
+@Suite(.serialized)
+@MainActor
+final class WorktreeListViewModelDetailRefreshTests {
+
+    private let repoDir: String
+    private let wtDir: String
+    private let fm = FileManager.default
+    private let executor = RefreshGitExecutor()
+    private let sut: WorktreeListViewModel
+
+    init() {
+        let base = NSTemporaryDirectory() + "DetailRefreshTests-\(UUID().uuidString)"
+        repoDir = base + "/repo"
+        wtDir = base + "/wt-feature"
+        try! fm.createDirectory(atPath: repoDir, withIntermediateDirectories: true)
+        try! fm.createDirectory(atPath: wtDir, withIntermediateDirectories: true)
+        sut = WorktreeListViewModel(
+            worktreeManager: WorktreeManager(executor: executor, fileManager: MockNoOpFileManager()),
+            store: .shared,
+            pullRequestService: MockNoPRService()
+        )
+        sut.repository = Repository(name: "refresh-test", path: repoDir)
+        executor.worktreeListOutput = """
+        worktree \(repoDir)
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree \(wtDir)
+        HEAD abc2222
+        branch refs/heads/feature/x
+
+        """
+    }
+
+    deinit {
+        let base = (repoDir as NSString).deletingLastPathComponent
+        try? FileManager.default.removeItem(atPath: base)
+    }
+
+    private func write(_ name: String, _ text: String, in dir: String) {
+        fm.createFile(atPath: (dir as NSString).appendingPathComponent(name), contents: Data(text.utf8))
+    }
+
+    @Test func loadWorktreesRefreshesSelectedWorktreeDetail() async {
+        write(".env", "A=1", in: repoDir)
+        write(".env", "A=1", in: wtDir)
+        await sut.loadWorktrees()
+        guard let feature = sut.worktrees.first(where: { $0.path == wtDir }) else {
+            Issue.record("feature worktree missing from \(sut.worktrees.map(\.path))")
+            return
+        }
+        sut.selectedWorktreeIDs = [feature.id]
+        await sut.loadDetail(for: feature)
+        #expect(sut.selectedWorktreeDetail?.copiedFiles.map(\.status) == [.identical])
+
+        // Edit the worktree's copy on disk, then refresh the list — the path every
+        // refresh trigger takes. The diff status must follow without reselecting.
+        write(".env", "A=1\nB=2", in: wtDir)
+        await sut.loadWorktrees()
+        #expect(sut.selectedWorktreeDetail?.copiedFiles.map(\.status) == [.modified])
+    }
+
+    @Test func loadWorktreesWithoutSelectionLeavesDetailEmpty() async {
+        write(".env", "A=1", in: wtDir)
+        await sut.loadWorktrees()
+        #expect(sut.selectedWorktreeDetail == nil)
+    }
+}

--- a/OhMyWorktreeTests/WorktreeListViewModelDetailRefreshTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelDetailRefreshTests.swift
@@ -96,4 +96,24 @@ final class WorktreeListViewModelDetailRefreshTests {
         await sut.loadWorktrees()
         #expect(sut.selectedWorktreeDetail == nil)
     }
+
+    @Test func debouncedLoadWorktreesStillRefreshesDetail() async {
+        write(".env", "A=1", in: repoDir)
+        write(".env", "A=1", in: wtDir)
+        await sut.loadWorktrees()
+        guard let feature = sut.worktrees.first(where: { $0.path == wtDir }) else {
+            Issue.record("feature worktree missing from \(sut.worktrees.map(\.path))")
+            return
+        }
+        sut.selectedWorktreeIDs = [feature.id]
+        await sut.loadDetail(for: feature)
+        #expect(sut.selectedWorktreeDetail?.copiedFiles.map(\.status) == [.identical])
+
+        // Edit the file, then refresh via the DEBOUNCED path (app activation,
+        // menu-bar open) inside the 2s window. The list reload is skipped — the
+        // selected worktree's detail must still pick up the file change.
+        write(".env", "A=1\nB=2", in: wtDir)
+        await sut.loadWorktrees(debounce: true)
+        #expect(sut.selectedWorktreeDetail?.copiedFiles.map(\.status) == [.modified])
+    }
 }

--- a/coverage-exclude.txt
+++ b/coverage-exclude.txt
@@ -35,6 +35,10 @@ OhMyWorktree/ViewModels/WorktreeListViewModel.swift
 # same async worktree-creation / detail-loading paths (filteredWorktrees IS tested via
 # WorktreeListViewModelSearchTests, but the file is quarantined with its parent).
 OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
+# Same async-glue category: copied-files browser state + the apply-to-main
+# coordinator (file write via CopiedFileDiffer + detail reload). Setters are
+# trivially testable but quarantined with their parent VM.
+OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
 #
 # (b) Coverage stable but much lower on CI than locally (not portable yet):
 OhMyWorktree/Models/Worktree.swift

--- a/docs/superpowers/plans/2026-06-08-copied-files-diff.md
+++ b/docs/superpowers/plans/2026-06-08-copied-files-diff.md
@@ -1,0 +1,1600 @@
+# Copied Files Diff & Apply-to-Main Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the detail pane's "Copied files" diff-aware — each `.worktreeinclude` copy is compared against the repository's (main worktree's) copy, shown as modified/new/identical, browsable in a searchable glass sheet that drills into a GitHub-style unified diff, with an "Apply to main" that overwrites main's local copy (behind a confirmation).
+
+**Architecture:** All behavior lives in `Models/` + `Services/` and is unit-tested to the repo's 100% gate; all rendering lives in `Views/` (coverage-excluded) and is verified by build + manual smoke. The diff is a content compare (these files are git-ignored, so `git diff` does not apply); "main" is `repository.path`. Apply writes the worktree's bytes back to `repository.path/<relpath>` atomically and never touches Git.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Testing (`@Suite`/`@Test`/`#expect`), `FileManager`. Design tokens in `OMWColor`/`OMWRadius`/`GlassSheetMetrics`. Reference design: `oh-my-worktree/project/{data,WorktreeWindow,Sheets}.jsx` + `omw.css`.
+
+---
+
+## Design notes locked for this plan
+
+- **Status model:** `enum CopiedFileStatus { case identical, modified, new }` plus a separate
+  `CopiedFile.isBinary: Bool`. Binary-identical = `.identical` + `isBinary`; binary-modified =
+  `.modified` + `isBinary`. `isClickable == (status != .identical)`. `isChanged == (status != .identical)`.
+- **Classification is pure** (`CopiedFile.classify(path:mainData:worktreeData:)`, takes `Data?`/`Data`),
+  so it is fully tested without file I/O. `CopiedFileDiffer` only does file reads/writes and calls it.
+- **Apply** uses `Data.write(to:options:.atomic)` — atomic overwrite that also creates the file when absent.
+
+## File Structure
+
+**Create (logic — 100% tested):**
+- `OhMyWorktree/Models/LineDiff.swift` — `DiffLine` + `LineDiff.compute`
+- `OhMyWorktree/Models/CopiedFile.swift` — `CopiedFileStatus`, `CopiedPath`, `CopiedFile` (+ `classify`)
+- `OhMyWorktree/Services/CopiedFileDiffer.swift` — `compare`, `applyToMain`
+- `OhMyWorktreeTests/LineDiffTests.swift`
+- `OhMyWorktreeTests/CopiedFileTests.swift`
+- `OhMyWorktreeTests/CopiedFileDifferTests.swift`
+
+**Create (views — coverage-excluded):**
+- `OhMyWorktree/Views/Detail/PathLabel.swift`
+- `OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift` (sheet: list ↔ diff drill-in, `CopiedFileRow`, `UnifiedDiffView`)
+- `OhMyWorktree/Views/Detail/CopiedToast.swift`
+
+**Modify:**
+- `OhMyWorktree/Models/WorktreeDetail.swift` — `copiedFiles: [String]` → `[CopiedFile]`
+- `OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift` — build `[CopiedFile]` in `loadDetail`
+- `OhMyWorktree/ViewModels/WorktreeListViewModel.swift` — browser/apply/toast state + glue + `differ`
+- `OhMyWorktree/Views/Detail/CopiedFilesSection.swift` — full diff-aware rewrite
+- `OhMyWorktree/Views/Detail/DetailPaneView.swift` — forward `onOpenCopiedDiff` / `onBrowseCopied`
+- `OhMyWorktree/Views/ContentView.swift` — present browser in `modalOverlay`, apply alert, toast
+- `OhMyWorktreeTests/WorktreeDetailTests.swift` — assert new `[CopiedFile]` shape
+
+**No `coverage-exclude.txt` changes.** All new logic is in `Models/`+`Services/` and must hit 100%.
+
+---
+
+### Task 1: Line diff (`DiffLine` + `LineDiff.compute`)
+
+LCS line diff ported from `data.jsx#diffLines`.
+
+**Files:**
+- Create: `OhMyWorktree/Models/LineDiff.swift`
+- Test: `OhMyWorktreeTests/LineDiffTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OhMyWorktreeTests/LineDiffTests.swift`:
+
+```swift
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct LineDiffTests {
+
+    @Test func identicalIsAllContext() {
+        let rows = LineDiff.compute("a\nb\nc", "a\nb\nc")
+        #expect(rows.allSatisfy { $0.kind == .context })
+        #expect(rows.map(\.text) == ["a", "b", "c"])
+        #expect(rows.map(\.lineA) == [1, 2, 3])
+        #expect(rows.map(\.lineB) == [1, 2, 3])
+    }
+
+    @Test func emptyMainIsAllAdds() {
+        let rows = LineDiff.compute("", "x\ny")
+        #expect(rows.map(\.kind) == [.add, .add])
+        #expect(rows.map(\.lineA) == [nil, nil])
+        #expect(rows.map(\.lineB) == [1, 2])
+    }
+
+    @Test func emptyWorktreeIsAllDels() {
+        let rows = LineDiff.compute("x\ny", "")
+        #expect(rows.map(\.kind) == [.del, .del])
+        #expect(rows.map(\.lineB) == [nil, nil])
+        #expect(rows.map(\.lineA) == [1, 2])
+    }
+
+    @Test func singleLineChangeIsDelThenAdd() {
+        let rows = LineDiff.compute("a\nB\nc", "a\nb\nc")
+        #expect(rows.map(\.kind) == [.context, .del, .add, .context])
+        #expect(rows.filter { $0.kind == .add }.map(\.text) == ["b"])
+        #expect(rows.filter { $0.kind == .del }.map(\.text) == ["B"])
+    }
+
+    @Test func appendedLinesAreAdds() {
+        let rows = LineDiff.compute("a", "a\nb\nc")
+        #expect(rows.map(\.kind) == [.context, .add, .add])
+        #expect(rows.last?.lineB == 3)
+    }
+
+    @Test func idsAreUniqueAndSequential() {
+        let rows = LineDiff.compute("a\nB", "a\nb")
+        #expect(rows.map(\.id) == Array(0..<rows.count))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "LineDiffTests\|error:"`
+Expected: build/compile failure — `LineDiff` / `DiffLine` are undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OhMyWorktree/Models/LineDiff.swift`:
+
+```swift
+import Foundation
+
+/// One line of a unified diff between two text blobs.
+struct DiffLine: Equatable, Sendable, Identifiable {
+    enum Kind: Equatable, Sendable { case context, add, del }
+    let kind: Kind
+    let text: String
+    /// 1-based line number on the "main" (a) side; nil for added lines.
+    let lineA: Int?
+    /// 1-based line number on the "worktree" (b) side; nil for deleted lines.
+    let lineB: Int?
+    /// Stable index assigned at build time (array position).
+    let id: Int
+}
+
+/// Minimal LCS line diff (port of the prototype's `data.jsx#diffLines`).
+enum LineDiff {
+
+    /// Compares `a` (main) against `b` (worktree), line by line.
+    /// An empty `a` yields all-adds; an empty `b` yields all-dels.
+    static func compute(_ a: String, _ b: String) -> [DiffLine] {
+        let aLines = a.components(separatedBy: "\n")
+        let bLines = b.components(separatedBy: "\n")
+
+        var raw: [(kind: DiffLine.Kind, text: String, lineA: Int?, lineB: Int?)] = []
+
+        if a.isEmpty {
+            for (i, line) in bLines.enumerated() {
+                raw.append((.add, line, nil, i + 1))
+            }
+        } else if b.isEmpty {
+            for (i, line) in aLines.enumerated() {
+                raw.append((.del, line, i + 1, nil))
+            }
+        } else {
+            let n = aLines.count
+            let m = bLines.count
+            // dp[i][j] = LCS length of aLines[i...] and bLines[j...]
+            var dp = Array(repeating: Array(repeating: 0, count: m + 1), count: n + 1)
+            if n > 0 && m > 0 {
+                for i in stride(from: n - 1, through: 0, by: -1) {
+                    for j in stride(from: m - 1, through: 0, by: -1) {
+                        dp[i][j] = aLines[i] == bLines[j]
+                            ? dp[i + 1][j + 1] + 1
+                            : max(dp[i + 1][j], dp[i][j + 1])
+                    }
+                }
+            }
+            var i = 0, j = 0
+            while i < n && j < m {
+                if aLines[i] == bLines[j] {
+                    raw.append((.context, aLines[i], i + 1, j + 1)); i += 1; j += 1
+                } else if dp[i + 1][j] >= dp[i][j + 1] {
+                    raw.append((.del, aLines[i], i + 1, nil)); i += 1
+                } else {
+                    raw.append((.add, bLines[j], nil, j + 1)); j += 1
+                }
+            }
+            while i < n { raw.append((.del, aLines[i], i + 1, nil)); i += 1 }
+            while j < m { raw.append((.add, bLines[j], nil, j + 1)); j += 1 }
+        }
+
+        return raw.enumerated().map { index, r in
+            DiffLine(kind: r.kind, text: r.text, lineA: r.lineA, lineB: r.lineB, id: index)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "LineDiffTests\|Test Suite.*passed\|error:"`
+Expected: PASS for all `LineDiffTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OhMyWorktree/Models/LineDiff.swift OhMyWorktreeTests/LineDiffTests.swift
+git commit -m "feat: add LineDiff LCS line-diff for copied files"
+```
+
+---
+
+### Task 2: `CopiedFileStatus`, `CopiedPath`, and `CopiedFile.classify`
+
+Pure status/diff classification, plus the path-split helper for `PathLabel`.
+
+**Files:**
+- Create: `OhMyWorktree/Models/CopiedFile.swift`
+- Test: `OhMyWorktreeTests/CopiedFileTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OhMyWorktreeTests/CopiedFileTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+struct CopiedFileTests {
+
+    private func data(_ s: String) -> Data { Data(s.utf8) }
+
+    // MARK: status flags
+
+    @Test func statusFlags() {
+        #expect(CopiedFileStatus.identical.isChanged == false)
+        #expect(CopiedFileStatus.modified.isChanged)
+        #expect(CopiedFileStatus.new.isChanged)
+        #expect(CopiedFileStatus.identical.isClickable == false)
+        #expect(CopiedFileStatus.modified.isClickable)
+        #expect(CopiedFileStatus.new.isClickable)
+        #expect(CopiedFileStatus.modified.sortRank < CopiedFileStatus.new.sortRank)
+        #expect(CopiedFileStatus.new.sortRank < CopiedFileStatus.identical.sortRank)
+    }
+
+    // MARK: path split
+
+    @Test func pathSplit() {
+        #expect(CopiedPath.split("apps/web/.env") == (dir: "apps/web/", base: ".env"))
+        #expect(CopiedPath.split(".env") == (dir: "", base: ".env"))
+        #expect(CopiedPath.split("a/") == (dir: "a/", base: ""))
+    }
+
+    // MARK: classify — text
+
+    @Test func classifyIdentical() {
+        let f = CopiedFile.classify(path: ".env", mainData: data("A=1"), worktreeData: data("A=1"))
+        #expect(f.status == .identical)
+        #expect(f.isBinary == false)
+        #expect(f.added == 0 && f.removed == 0)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func classifyModifiedCountsLines() {
+        let f = CopiedFile.classify(path: ".env",
+                                    mainData: data("A=1\nB=2"),
+                                    worktreeData: data("A=1\nB=3\nC=4"))
+        #expect(f.status == .modified)
+        #expect(f.isBinary == false)
+        #expect(f.added == 2)    // "B=3", "C=4"
+        #expect(f.removed == 1)  // "B=2"
+        #expect(f.lines.isEmpty == false)
+        #expect(f.mainContent == "A=1\nB=2")
+        #expect(f.worktreeContent == "A=1\nB=3\nC=4")
+    }
+
+    @Test func classifyNewIsAllAdds() {
+        let f = CopiedFile.classify(path: "new.env", mainData: nil, worktreeData: data("X=1\nY=2"))
+        #expect(f.status == .new)
+        #expect(f.isBinary == false)
+        #expect(f.added == 2 && f.removed == 0)
+        #expect(f.lines.map(\.kind) == [.add, .add])
+        #expect(f.mainContent == nil)
+    }
+
+    // MARK: classify — binary
+
+    @Test func classifyBinaryIdentical() {
+        let bytes = Data([0xFF, 0x00, 0xFE])
+        let f = CopiedFile.classify(path: "a.bin", mainData: bytes, worktreeData: bytes)
+        #expect(f.status == .identical)
+        #expect(f.isBinary)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func classifyBinaryModified() {
+        let f = CopiedFile.classify(path: "a.bin",
+                                    mainData: Data([0xFF, 0x00]),
+                                    worktreeData: Data([0xFF, 0x01]))
+        #expect(f.status == .modified)
+        #expect(f.isBinary)
+        #expect(f.added == 0 && f.removed == 0)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func classifyNewBinary() {
+        let f = CopiedFile.classify(path: "k.p12", mainData: nil, worktreeData: Data([0x00, 0xFF]))
+        #expect(f.status == .new)
+        #expect(f.isBinary)
+        #expect(f.lines.isEmpty)
+    }
+
+    @Test func identifiableUsesPath() {
+        let f = CopiedFile.classify(path: "x/.env", mainData: data("a"), worktreeData: data("a"))
+        #expect(f.id == "x/.env")
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "CopiedFileTests\|error:"`
+Expected: compile failure — `CopiedFile`, `CopiedFileStatus`, `CopiedPath` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OhMyWorktree/Models/CopiedFile.swift`:
+
+```swift
+import Foundation
+
+/// How a worktree's copied file relates to the repository's (main's) copy.
+enum CopiedFileStatus: Equatable, Sendable {
+    case identical   // bytes equal
+    case modified    // present in both, bytes differ
+    case new         // present in the worktree, absent in main
+
+    /// Differs from main (anything worth surfacing / applying).
+    var isChanged: Bool { self != .identical }
+    /// Has something to open (a diff to view or content to copy back).
+    var isClickable: Bool { self != .identical }
+    /// Ordering for chips/list: changed first, then new, then identical.
+    var sortRank: Int {
+        switch self {
+        case .modified: 0
+        case .new: 1
+        case .identical: 2
+        }
+    }
+}
+
+/// Splits a repo-relative path into its directory (with trailing slash) and filename.
+enum CopiedPath {
+    static func split(_ path: String) -> (dir: String, base: String) {
+        guard let slash = path.lastIndex(of: "/") else { return (dir: "", base: path) }
+        let after = path.index(after: slash)
+        return (dir: String(path[...slash]), base: String(path[after...]))
+    }
+}
+
+/// A `.worktreeinclude` copied file compared against main, with its line diff.
+struct CopiedFile: Equatable, Sendable, Identifiable {
+    let path: String
+    let status: CopiedFileStatus
+    let isBinary: Bool
+    let added: Int
+    let removed: Int
+    let mainContent: String?
+    let worktreeContent: String?
+    let lines: [DiffLine]
+
+    var id: String { path }
+
+    /// Classifies a copied file from raw bytes. `mainData == nil` ⇒ `.new`.
+    /// Non-UTF-8 on either side ⇒ binary (byte-compared, no line preview).
+    static func classify(path: String, mainData: Data?, worktreeData: Data) -> CopiedFile {
+        let worktreeText = String(data: worktreeData, encoding: .utf8)
+
+        guard let mainData else {
+            // New file — not in main.
+            if let worktreeText {
+                let lines = LineDiff.compute("", worktreeText)
+                return CopiedFile(path: path, status: .new, isBinary: false,
+                                  added: lines.count, removed: 0,
+                                  mainContent: nil, worktreeContent: worktreeText, lines: lines)
+            }
+            return CopiedFile(path: path, status: .new, isBinary: true,
+                              added: 0, removed: 0,
+                              mainContent: nil, worktreeContent: nil, lines: [])
+        }
+
+        let mainText = String(data: mainData, encoding: .utf8)
+        let isBinary = (mainText == nil) || (worktreeText == nil)
+
+        if mainData == worktreeData {
+            return CopiedFile(path: path, status: .identical, isBinary: isBinary,
+                              added: 0, removed: 0,
+                              mainContent: mainText, worktreeContent: worktreeText, lines: [])
+        }
+
+        guard !isBinary, let mainText, let worktreeText else {
+            return CopiedFile(path: path, status: .modified, isBinary: true,
+                              added: 0, removed: 0,
+                              mainContent: mainText, worktreeContent: worktreeText, lines: [])
+        }
+
+        let lines = LineDiff.compute(mainText, worktreeText)
+        return CopiedFile(
+            path: path, status: .modified, isBinary: false,
+            added: lines.filter { $0.kind == .add }.count,
+            removed: lines.filter { $0.kind == .del }.count,
+            mainContent: mainText, worktreeContent: worktreeText, lines: lines
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "CopiedFileTests\|error:"`
+Expected: PASS for all `CopiedFileTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OhMyWorktree/Models/CopiedFile.swift OhMyWorktreeTests/CopiedFileTests.swift
+git commit -m "feat: add CopiedFile status classification + path split"
+```
+
+---
+
+### Task 3: `CopiedFileDiffer` (compare + applyToMain)
+
+File I/O service: reads both copies to build `[CopiedFile]`, and writes a copy back to main.
+
+**Files:**
+- Create: `OhMyWorktree/Services/CopiedFileDiffer.swift`
+- Test: `OhMyWorktreeTests/CopiedFileDifferTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `OhMyWorktreeTests/CopiedFileDifferTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import OhMyWorktree
+
+@Suite
+final class CopiedFileDifferTests {
+
+    private let repoDir: String
+    private let worktreeDir: String
+    private let fm = FileManager.default
+    private let sut = CopiedFileDiffer()
+
+    init() {
+        let base = NSTemporaryDirectory() + "CopiedFileDifferTests-\(UUID().uuidString)"
+        repoDir = base + "/repo"
+        worktreeDir = base + "/worktree"
+        try! fm.createDirectory(atPath: repoDir, withIntermediateDirectories: true)
+        try! fm.createDirectory(atPath: worktreeDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        let base = (repoDir as NSString).deletingLastPathComponent
+        try? fm.removeItem(atPath: base)
+    }
+
+    private func write(_ rel: String, in dir: String, _ bytes: Data) {
+        let full = (dir as NSString).appendingPathComponent(rel)
+        try! fm.createDirectory(atPath: (full as NSString).deletingLastPathComponent,
+                                withIntermediateDirectories: true)
+        fm.createFile(atPath: full, contents: bytes)
+    }
+
+    private func write(_ rel: String, in dir: String, _ text: String) {
+        write(rel, in: dir, Data(text.utf8))
+    }
+
+    private func read(_ rel: String, in dir: String) -> Data? {
+        fm.contents(atPath: (dir as NSString).appendingPathComponent(rel))
+    }
+
+    // MARK: compare
+
+    @Test func compareClassifiesAndSorts() {
+        write("apps/a/.env", in: repoDir, "A=1")
+        write("apps/a/.env", in: worktreeDir, "A=2")       // modified
+        write("same.env", in: repoDir, "X=1")
+        write("same.env", in: worktreeDir, "X=1")          // identical
+        write("brand.env", in: worktreeDir, "N=1")         // new (only in worktree)
+
+        let files = sut.compare(relativePaths: ["same.env", "apps/a/.env", "brand.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        // sorted: modified(0) → new(1) → identical(2)
+        #expect(files.map(\.path) == ["apps/a/.env", "brand.env", "same.env"])
+        #expect(files.map(\.status) == [.modified, .new, .identical])
+    }
+
+    @Test func compareSkipsMissingWorktreeFile() {
+        write("ghost.env", in: repoDir, "A=1")   // exists in main, not in worktree
+        let files = sut.compare(relativePaths: ["ghost.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+        #expect(files.isEmpty)
+    }
+
+    @Test func compareDetectsBinaryModified() {
+        write("a.bin", in: repoDir, Data([0xFF, 0x00]))
+        write("a.bin", in: worktreeDir, Data([0xFF, 0x01]))
+        let files = sut.compare(relativePaths: ["a.bin"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+        #expect(files.first?.status == .modified)
+        #expect(files.first?.isBinary == true)
+    }
+
+    // MARK: applyToMain
+
+    @Test func applyOverwritesExistingMainCopy() throws {
+        write("apps/a/.env", in: repoDir, "A=1")
+        write("apps/a/.env", in: worktreeDir, "A=2\nB=3")
+        let file = sut.compare(relativePaths: ["apps/a/.env"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+
+        try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        #expect(read("apps/a/.env", in: repoDir) == Data("A=2\nB=3".utf8))
+        // re-comparing now reports identical
+        let after = sut.compare(relativePaths: ["apps/a/.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(after.status == .identical)
+    }
+
+    @Test func applyCopiesNewFileCreatingDirs() throws {
+        write("config/local/new.json", in: worktreeDir, "{}")
+        let file = sut.compare(relativePaths: ["config/local/new.json"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(file.status == .new)
+
+        try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        #expect(read("config/local/new.json", in: repoDir) == Data("{}".utf8))
+    }
+
+    @Test func applyThrowsWhenSourceMissing() {
+        let phantom = CopiedFile(path: "gone.env", status: .new, isBinary: false,
+                                 added: 0, removed: 0, mainContent: nil,
+                                 worktreeContent: nil, lines: [])
+        #expect(throws: (any Error).self) {
+            try sut.applyToMain(phantom, worktreePath: worktreeDir, repositoryPath: repoDir)
+        }
+    }
+
+    @Test func applyThrowsWhenDestDirBlockedByFile() {
+        // A *file* named "blocker" in repo blocks creating dir "blocker/".
+        write("blocker", in: repoDir, "x")
+        write("blocker/x.env", in: worktreeDir, "A=1")
+        let file = sut.compare(relativePaths: ["blocker/x.env"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(throws: (any Error).self) {
+            try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "CopiedFileDifferTests\|error:"`
+Expected: compile failure — `CopiedFileDiffer` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `OhMyWorktree/Services/CopiedFileDiffer.swift`:
+
+```swift
+import Foundation
+
+/// Compares a worktree's copied (`.worktreeinclude`) files against the
+/// repository's (main worktree's) copies, and applies a worktree copy back to main.
+/// Stateless; safe to instantiate per call.
+final class CopiedFileDiffer: Sendable {
+
+    /// Builds a `CopiedFile` per relative path by reading both copies.
+    /// Paths absent in the worktree are skipped (the list is derived from a
+    /// worktree scan, so this is defensive). Result is sorted changed → new → identical.
+    func compare(relativePaths: [String], worktreePath: String, repositoryPath: String) -> [CopiedFile] {
+        let fm = FileManager.default
+        let files: [CopiedFile] = relativePaths.compactMap { rel in
+            let worktreeFull = (worktreePath as NSString).appendingPathComponent(rel)
+            guard let worktreeData = fm.contents(atPath: worktreeFull) else { return nil }
+            let mainFull = (repositoryPath as NSString).appendingPathComponent(rel)
+            let mainData = fm.contents(atPath: mainFull)
+            return CopiedFile.classify(path: rel, mainData: mainData, worktreeData: worktreeData)
+        }
+        return files.sorted { lhs, rhs in
+            lhs.status.sortRank != rhs.status.sortRank
+                ? lhs.status.sortRank < rhs.status.sortRank
+                : lhs.path < rhs.path
+        }
+    }
+
+    /// Overwrites main's local copy of `file` with the worktree's bytes (atomically;
+    /// creates the file and parent directories when absent). Never touches Git.
+    func applyToMain(_ file: CopiedFile, worktreePath: String, repositoryPath: String) throws {
+        let fm = FileManager.default
+        let source = URL(fileURLWithPath: (worktreePath as NSString).appendingPathComponent(file.path))
+        let dest = URL(fileURLWithPath: (repositoryPath as NSString).appendingPathComponent(file.path))
+        let destDir = (dest.path as NSString).deletingLastPathComponent
+        try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true)
+        let data = try Data(contentsOf: source)
+        try data.write(to: dest, options: .atomic)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "CopiedFileDifferTests\|error:"`
+Expected: PASS for all `CopiedFileDifferTests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OhMyWorktree/Services/CopiedFileDiffer.swift OhMyWorktreeTests/CopiedFileDifferTests.swift
+git commit -m "feat: add CopiedFileDiffer compare + applyToMain"
+```
+
+---
+
+### Task 4: Change `WorktreeDetail.copiedFiles` to `[CopiedFile]` and populate it
+
+Switch the model type and build `[CopiedFile]` in `loadDetail`. Keep the build green by
+updating every consumer minimally (the full UI rewrite comes in later tasks).
+
+**Files:**
+- Modify: `OhMyWorktree/Models/WorktreeDetail.swift:33-34`
+- Modify: `OhMyWorktree/ViewModels/WorktreeListViewModel.swift` (add `differ`)
+- Modify: `OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift:98-103`
+- Modify: `OhMyWorktree/Views/Detail/CopiedFilesSection.swift` (signature only, minimal)
+- Test: `OhMyWorktreeTests/WorktreeDetailTests.swift` (add a `[CopiedFile]` assertion)
+
+- [ ] **Step 1: Write/extend the failing test**
+
+In `OhMyWorktreeTests/WorktreeDetailTests.swift`, inside `struct WorktreeDetailModelTests`, add:
+
+```swift
+    @Test func copiedFilesHoldClassifiedEntries() {
+        let file = CopiedFile.classify(path: ".env",
+                                       mainData: Data("A=1".utf8),
+                                       worktreeData: Data("A=2".utf8))
+        let detail = WorktreeDetail(aheadBehind: nil,
+                                    diff: DiffStat(added: 0, removed: 0, files: 0),
+                                    commits: [],
+                                    copiedFiles: [file])
+        #expect(detail.copiedFiles.map(\.status) == [.modified])
+        #expect(detail.copiedFiles.first?.path == ".env")
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | grep -i "copiedFilesHoldClassified\|error:"`
+Expected: compile failure — `WorktreeDetail.init` still expects `[String]` for `copiedFiles`.
+
+- [ ] **Step 3: Change the model**
+
+In `OhMyWorktree/Models/WorktreeDetail.swift`, replace lines 33-34:
+
+```swift
+    /// Files copied into the worktree per `.worktreeinclude` (or `.env*`).
+    var copiedFiles: [String] = []
+```
+
+with:
+
+```swift
+    /// Files copied into the worktree per `.worktreeinclude` (or `.env*`),
+    /// each classified against main (the repository copy) for diff display.
+    var copiedFiles: [CopiedFile] = []
+```
+
+- [ ] **Step 4: Inject the differ into the view model**
+
+In `OhMyWorktree/ViewModels/WorktreeListViewModel.swift`, next to the existing
+`let fileCopier: WorktreeFileCopier` stored property (around line 68), add:
+
+```swift
+    let differ: CopiedFileDiffer
+```
+
+In the same file's `init`, find the parameter list containing
+`fileCopier: WorktreeFileCopier = WorktreeFileCopier(),` (around line 90) and add a parameter:
+
+```swift
+        differ: CopiedFileDiffer = CopiedFileDiffer(),
+```
+
+and in the init body, next to `self.fileCopier = fileCopier` (around line 96), add:
+
+```swift
+        self.differ = differ
+```
+
+- [ ] **Step 5: Build `[CopiedFile]` in `loadDetail`**
+
+In `OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift`, replace lines 98-103:
+
+```swift
+        let copier = fileCopier
+        let path = worktree.path
+        let matches = await Task.detached { copier.includedFiles(in: path) }.value
+        // Only files Git ignores were actually copied; committed templates
+        // (e.g. .env.example) come with the checkout and don't count.
+        detail.copiedFiles = await worktreeManager.gitIgnoredFiles(matches, worktreePath: path)
+```
+
+with:
+
+```swift
+        let copier = fileCopier
+        let differ = self.differ
+        let path = worktree.path
+        let repoPath = repository.path
+        let matches = await Task.detached { copier.includedFiles(in: path) }.value
+        // Only files Git ignores were actually copied; committed templates
+        // (e.g. .env.example) come with the checkout and don't count.
+        let ignored = await worktreeManager.gitIgnoredFiles(matches, worktreePath: path)
+        detail.copiedFiles = await Task.detached {
+            differ.compare(relativePaths: ignored, worktreePath: path, repositoryPath: repoPath)
+        }.value
+```
+
+- [ ] **Step 6: Keep `CopiedFilesSection` compiling (minimal)**
+
+In `OhMyWorktree/Views/Detail/CopiedFilesSection.swift`, change the stored property and the
+two places that consume the strings so it still builds (it will be fully rewritten in Task 6).
+
+Replace `let files: [String]` (line 6) with:
+
+```swift
+    let files: [CopiedFile]
+```
+
+Replace the filtered/shown computation in `body` (lines 16-19):
+
+```swift
+        let filtered = query.isEmpty
+            ? files
+            : files.filter { $0.lowercased().contains(query.lowercased()) }
+        let shown = (!expanded && many) ? Array(files.prefix(cap)) : filtered
+```
+
+with:
+
+```swift
+        let names = files.map(\.path)
+        let filtered = query.isEmpty
+            ? names
+            : names.filter { $0.lowercased().contains(query.lowercased()) }
+        let shown = (!expanded && many) ? Array(names.prefix(cap)) : filtered
+```
+
+(`chips(shown:)` already takes `[String]` and renders `CopiedFileChip(name:)`, so no other change is needed here.)
+
+- [ ] **Step 7: Run the full test scheme to verify green**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | tail -25`
+Expected: build succeeds; all suites PASS (including `copiedFilesHoldClassifiedEntries` and the unchanged `emptyDetailHasNoData`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add OhMyWorktree/Models/WorktreeDetail.swift \
+        OhMyWorktree/ViewModels/WorktreeListViewModel.swift \
+        OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift \
+        OhMyWorktree/Views/Detail/CopiedFilesSection.swift \
+        OhMyWorktreeTests/WorktreeDetailTests.swift
+git commit -m "feat: classify copied files in detail load ([CopiedFile])"
+```
+
+---
+
+### Task 5: View model browser/apply/toast state + glue
+
+Add the state the UI binds to and the thin apply glue (real work is in the tested service).
+
+**Files:**
+- Modify: `OhMyWorktree/ViewModels/WorktreeListViewModel.swift`
+
+- [ ] **Step 1: Add observable state**
+
+In `OhMyWorktree/ViewModels/WorktreeListViewModel.swift`, near `var selectedWorktreeDetail: WorktreeDetail?` (line 30), add:
+
+```swift
+    /// When non-nil, the copied-files browser sheet is open. `focusedPath`, when
+    /// set, opens straight to that file's diff (drill-in); nil shows the list.
+    var copiedBrowser: CopiedBrowserState?
+    /// A copied file awaiting Apply-to-main confirmation.
+    var pendingApply: CopiedFile?
+    /// Transient success message shown as a toast after an apply.
+    var copiedToast: String?
+```
+
+- [ ] **Step 2: Define the state struct + glue methods**
+
+At the end of `OhMyWorktree/ViewModels/WorktreeListViewModel.swift`, before the final closing brace
+of the `class`, add:
+
+```swift
+    /// Open state for the copied-files browser sheet.
+    struct CopiedBrowserState: Equatable {
+        var worktree: Worktree
+        var focusedPath: String?
+    }
+
+    /// Opens the browser to the full list for `worktree`.
+    func browseCopiedFiles(for worktree: Worktree) {
+        copiedBrowser = CopiedBrowserState(worktree: worktree, focusedPath: nil)
+    }
+
+    /// Opens the browser straight to `file`'s diff for `worktree`.
+    func openCopiedDiff(_ file: CopiedFile, for worktree: Worktree) {
+        copiedBrowser = CopiedBrowserState(worktree: worktree, focusedPath: file.path)
+    }
+
+    /// Applies `file` (worktree → main), reloads the detail so statuses refresh,
+    /// and shows a toast. Surfaces failures through the standard error alert.
+    func applyCopiedFileToMain(_ file: CopiedFile, in worktree: Worktree) async {
+        guard let repository else { return }
+        let differ = self.differ
+        let worktreePath = worktree.path
+        let repoPath = repository.path
+        do {
+            try await Task.detached {
+                try differ.applyToMain(file, worktreePath: worktreePath, repositoryPath: repoPath)
+            }.value
+            await loadDetail(for: worktree)
+            copiedToast = "Applied \((file.path as NSString).lastPathComponent) to main"
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED (new state is unused for now — that is expected; it is wired in Task 7).
+
+- [ ] **Step 4: Run the test scheme (no behavior change, must stay green)**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | tail -8`
+Expected: all suites PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+git commit -m "feat: copied-files browser/apply/toast state in view model"
+```
+
+---
+
+### Task 6: `PathLabel` + diff-aware `CopiedFilesSection` rewrite
+
+Replace the inline expand/filter section with the prototype's diff-aware header + status chips +
+"View all" affordance. Views are coverage-excluded — verify by build + manual smoke.
+
+**Files:**
+- Create: `OhMyWorktree/Views/Detail/PathLabel.swift`
+- Modify: `OhMyWorktree/Views/Detail/CopiedFilesSection.swift` (full rewrite)
+
+- [ ] **Step 1: Create `PathLabel`**
+
+Create `OhMyWorktree/Views/Detail/PathLabel.swift`:
+
+```swift
+import SwiftUI
+
+/// Renders a repo-relative path so the directory truncates with an ellipsis while
+/// the filename is always fully visible. Full path shown on hover (CSS `.pl`).
+/// Font/size come from the caller (`.font(...)`); only the directory is recolored
+/// to tertiary — the filename inherits the surrounding foreground style.
+struct PathLabel: View {
+    let path: String
+
+    var body: some View {
+        let parts = CopiedPath.split(path)
+        HStack(spacing: 0) {
+            if !parts.dir.isEmpty {
+                Text(parts.dir)
+                    .foregroundStyle(OMWColor.labelTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .layoutPriority(0)
+            }
+            Text(parts.base)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(1)
+        }
+        .help(path)
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `CopiedFilesSection`**
+
+Replace the entire contents of `OhMyWorktree/Views/Detail/CopiedFilesSection.swift` with:
+
+```swift
+import SwiftUI
+
+/// Detail-pane "Copied files" section: a compact one-line header with a changed
+/// count, status chips (modified `+N −N` / `new` / dimmed identical), and a
+/// "View all" button that opens the searchable browser sheet.
+struct CopiedFilesSection: View {
+    let files: [CopiedFile]
+    var onOpenDiff: (CopiedFile) -> Void = { _ in }
+    var onBrowseAll: () -> Void = {}
+
+    private let cap = 5
+
+    private var sorted: [CopiedFile] {
+        files.sorted { lhs, rhs in
+            lhs.status.sortRank != rhs.status.sortRank
+                ? lhs.status.sortRank < rhs.status.sortRank
+                : lhs.path < rhs.path
+        }
+    }
+    private var changedCount: Int { files.filter { $0.status.isChanged }.count }
+
+    var body: some View {
+        let many = files.count > cap
+        let shown = many ? Array(sorted.prefix(cap)) : sorted
+
+        VStack(alignment: .leading, spacing: 10) {
+            header
+            FlowLayout(spacing: 6) {
+                ForEach(shown) { chip($0) }
+            }
+            if many { viewAllButton }
+        }
+        .padding(.init(top: 14, leading: 18, bottom: 14, trailing: 18))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .overlay(alignment: .top) { Rectangle().fill(OMWColor.separator).frame(height: 0.5) }
+    }
+
+    private var header: some View {
+        HStack(spacing: 0) {
+            HStack(spacing: 5) {
+                Text("Copied files")
+                    .font(.system(size: 11, weight: .bold))
+                    .textCase(.uppercase)
+                    .tracking(0.3)
+                    .foregroundStyle(OMWColor.labelTertiary)
+                Text("\(files.count)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(OMWColor.labelTertiary)
+                if changedCount > 0 {
+                    Text("· \(changedCount) changed")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(OMWColor.sysOrange)
+                }
+            }
+            Spacer()
+            Text(".worktreeinclude")
+                .font(.omwMono(10))
+                .foregroundStyle(OMWColor.labelQuaternary)
+        }
+    }
+
+    @ViewBuilder
+    private func chip(_ file: CopiedFile) -> some View {
+        let clickable = file.status.isClickable
+        Button { if clickable { onOpenDiff(file) } } label: {
+            HStack(spacing: 5) {
+                switch file.status {
+                case .modified: Circle().fill(OMWColor.sysOrange).frame(width: 6, height: 6)
+                case .new: Circle().fill(OMWColor.sysGreen).frame(width: 6, height: 6)
+                case .identical: Image(systemName: "doc").font(.system(size: 11))
+                }
+                PathLabel(path: file.path)
+                    .font(.omwMono(11, weight: .medium))
+                if file.status == .modified {
+                    HStack(spacing: 4) {
+                        Text("+\(file.added)").foregroundStyle(OMWColor.sysGreen)
+                        Text("−\(file.removed)").foregroundStyle(OMWColor.sysRed)
+                    }
+                    .font(.omwMono(11, weight: .bold))
+                } else if file.status == .new {
+                    Text("new")
+                        .font(.system(size: 9, weight: .bold))
+                        .textCase(.uppercase)
+                        .tracking(0.4)
+                        .foregroundStyle(OMWColor.sysGreen)
+                }
+            }
+            .foregroundStyle(file.status == .identical ? OMWColor.labelSecondary : OMWColor.labelPrimary)
+            .padding(.horizontal, 9)
+            .frame(height: 22)
+            .background(chipBackground(file.status), in: Capsule())
+            .opacity(file.status == .identical ? 0.48 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(!clickable)
+        .help(clickable ? "\(file.path) — click to compare with main" : "\(file.path) — identical to main")
+    }
+
+    private func chipBackground(_ status: CopiedFileStatus) -> Color {
+        switch status {
+        case .modified: OMWColor.sysOrange.opacity(0.15)
+        case .new: OMWColor.sysGreen.opacity(0.15)
+        case .identical: OMWColor.fillTertiary
+        }
+    }
+
+    private var viewAllButton: some View {
+        Button(action: onBrowseAll) {
+            HStack(spacing: 7) {
+                Image(systemName: "list.bullet").font(.system(size: 13))
+                Text("View all \(files.count) files").font(.system(size: 12, weight: .medium))
+                Spacer()
+                Image(systemName: "chevron.right").font(.system(size: 11)).foregroundStyle(OMWColor.labelTertiary)
+            }
+            .foregroundStyle(OMWColor.labelSecondary)
+            .padding(.horizontal, 11)
+            .frame(height: 30)
+            .frame(maxWidth: .infinity)
+            .background(OMWColor.fillTertiary, in: RoundedRectangle(cornerRadius: OMWRadius.md))
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED. (`DetailPaneView` still calls `CopiedFilesSection(files:)`; the new
+closure params default to no-ops, so it compiles. Clicking does nothing until Task 8.)
+
+- [ ] **Step 4: Run swiftlint**
+
+Run: `swiftlint lint --quiet OhMyWorktree/Views/Detail/CopiedFilesSection.swift OhMyWorktree/Views/Detail/PathLabel.swift`
+Expected: no violations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add OhMyWorktree/Views/Detail/PathLabel.swift OhMyWorktree/Views/Detail/CopiedFilesSection.swift
+git commit -m "feat: diff-aware copied-files chips + PathLabel"
+```
+
+---
+
+### Task 7: `CopiedFilesBrowser` sheet (list ↔ diff drill-in)
+
+The single glass sheet: searchable list with a "Changed only" filter that drills into a
+GitHub-style unified diff and applies back to main. Includes `CopiedFileRow` and `UnifiedDiffView`.
+
+**Files:**
+- Create: `OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift`
+
+- [ ] **Step 1: Create the browser sheet**
+
+Create `OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift`:
+
+```swift
+import SwiftUI
+
+/// One glass sheet that browses a worktree's copied files and drills into a
+/// unified diff vs. main. `focusedPath` (re-resolved against `files` each render so
+/// it reflects applied changes) opens straight to that file's diff.
+struct CopiedFilesBrowser: View {
+    let files: [CopiedFile]
+    @Binding var focusedPath: String?
+    var onApply: (CopiedFile) -> Void
+    var onClose: () -> Void
+
+    @Environment(\.omwAccent) private var accent
+    @State private var query = ""
+    @State private var changedOnly = false
+
+    private var changedCount: Int { files.filter { $0.status.isChanged }.count }
+
+    private var active: CopiedFile? {
+        guard let focusedPath else { return nil }
+        return files.first { $0.path == focusedPath }
+    }
+
+    private var sorted: [CopiedFile] {
+        files.sorted { lhs, rhs in
+            lhs.status.sortRank != rhs.status.sortRank
+                ? lhs.status.sortRank < rhs.status.sortRank
+                : lhs.path < rhs.path
+        }
+    }
+
+    private var filtered: [CopiedFile] {
+        sorted.filter { file in
+            (!changedOnly || file.status.isChanged)
+                && (query.isEmpty || file.path.lowercased().contains(query.lowercased()))
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let active {
+                diffView(active)
+            } else {
+                listView
+            }
+        }
+        .frame(width: 520)
+        .frame(maxHeight: 560)
+        .glassSheet()
+        .tint(accent)
+        .onExitCommand { focusedPath != nil ? (focusedPath = nil) : onClose() }
+    }
+
+    // MARK: List
+
+    private var listView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline) {
+                HStack(spacing: 7) {
+                    Text("Copied files").font(.system(size: 14, weight: .bold))
+                    Text("\(files.count)").font(.system(size: 12, weight: .semibold)).foregroundStyle(OMWColor.labelTertiary)
+                    if changedCount > 0 {
+                        Text("· \(changedCount) changed vs. main")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(OMWColor.sysOrange)
+                    }
+                }
+                Spacer()
+                Text(".worktreeinclude").font(.omwMono(11)).foregroundStyle(OMWColor.labelQuaternary)
+            }
+            .padding(.init(top: 16, leading: 18, bottom: 0, trailing: 18))
+
+            HStack(spacing: 9) {
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass").font(.system(size: 12)).foregroundStyle(OMWColor.labelTertiary)
+                    TextField("Filter files…", text: $query).textFieldStyle(.plain).font(.system(size: 12))
+                }
+                .padding(.horizontal, 10).frame(height: 28)
+                .background(OMWColor.controlBg, in: Capsule())
+                .overlay(Capsule().strokeBorder(OMWColor.separator, lineWidth: 0.5))
+
+                if changedCount > 0 {
+                    Button { changedOnly.toggle() } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: changedOnly ? "checkmark" : "arrow.left.arrow.right").font(.system(size: 12))
+                            Text("Changed only").font(.system(size: 11, weight: .semibold))
+                        }
+                        .foregroundStyle(changedOnly ? OMWColor.onAccent : OMWColor.labelSecondary)
+                        .padding(.horizontal, 11).frame(height: 28)
+                        .background(changedOnly ? AnyShapeStyle(accent) : AnyShapeStyle(OMWColor.fillTertiary), in: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.init(top: 12, leading: 18, bottom: 4, trailing: 18))
+
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(filtered) { file in
+                        CopiedFileRow(file: file) { focusedPath = file.path }
+                    }
+                    if filtered.isEmpty {
+                        Text("No files match “\(query)”.")
+                            .font(.system(size: 13)).foregroundStyle(OMWColor.labelTertiary)
+                            .frame(maxWidth: .infinity).padding(.vertical, 26)
+                    }
+                }
+                .padding(.init(top: 6, leading: 12, bottom: 12, trailing: 12))
+            }
+
+            footer(hint: "Click a changed file to view its diff and apply it back to main.") {
+                Button("Done", action: onClose)
+                    .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+    }
+
+    // MARK: Diff drill-in
+
+    private func diffView(_ file: CopiedFile) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Button { focusedPath = nil } label: {
+                    HStack(spacing: 2) {
+                        Image(systemName: "chevron.left").font(.system(size: 13, weight: .semibold))
+                        Text("All files").font(.system(size: 12.5, weight: .semibold))
+                    }
+                    .foregroundStyle(accent)
+                    .padding(.init(top: 4, leading: 4, bottom: 4, trailing: 8))
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                Text(file.status == .new ? "new file — not in main" : "comparing vs. main")
+                    .font(.omwMono(11)).foregroundStyle(OMWColor.labelQuaternary)
+            }
+            .padding(.init(top: 12, leading: 14, bottom: 0, trailing: 14))
+
+            PathLabel(path: file.path)
+                .font(.omwMono(14, weight: .bold))
+                .foregroundStyle(OMWColor.labelPrimary)
+                .padding(.init(top: 8, leading: 18, bottom: 0, trailing: 18))
+
+            UnifiedDiffView(file: file)
+                .padding(.init(top: 12, leading: 18, bottom: 4, trailing: 18))
+
+            footer(hint: "Updates main’s local copy only — nothing is committed to Git.") {
+                Button { onApply(file) } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.left.to.line").font(.system(size: 13))
+                        Text(file.status == .new ? "Copy to main" : "Apply to main").font(.system(size: 13, weight: .semibold))
+                    }
+                }
+                .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
+            }
+        }
+    }
+
+    // MARK: Footer
+
+    private func footer(hint: String, @ViewBuilder trailing: () -> some View) -> some View {
+        HStack(spacing: 14) {
+            Text(hint).font(.system(size: 11)).foregroundStyle(OMWColor.labelTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+            trailing()
+        }
+        .padding(.init(top: 12, leading: 18, bottom: 14, trailing: 18))
+        .overlay(alignment: .top) { Rectangle().fill(OMWColor.separator).frame(height: 0.5) }
+    }
+}
+
+/// A full-width row in the browser list: status dot · path · `+N −N`/`new`/`identical` · chevron.
+private struct CopiedFileRow: View {
+    let file: CopiedFile
+    var onSelect: () -> Void
+
+    var body: some View {
+        let clickable = file.status.isClickable
+        Button { if clickable { onSelect() } } label: {
+            HStack(spacing: 9) {
+                Circle().fill(dotColor).frame(width: 7, height: 7)
+                PathLabel(path: file.path).font(.omwMono(12.5, weight: .medium)).foregroundStyle(OMWColor.labelPrimary)
+                Spacer(minLength: 8)
+                switch file.status {
+                case .modified:
+                    HStack(spacing: 4) {
+                        Text("+\(file.added)").foregroundStyle(OMWColor.sysGreen)
+                        Text("−\(file.removed)").foregroundStyle(OMWColor.sysRed)
+                    }
+                    .font(.omwMono(12, weight: .bold))
+                case .new:
+                    Text("new").font(.system(size: 10, weight: .bold)).textCase(.uppercase)
+                        .tracking(0.4).foregroundStyle(OMWColor.sysGreen)
+                case .identical:
+                    Text("identical").font(.system(size: 10, weight: .medium)).foregroundStyle(OMWColor.labelTertiary)
+                }
+                if clickable {
+                    Image(systemName: "chevron.right").font(.system(size: 12)).foregroundStyle(OMWColor.labelTertiary)
+                }
+            }
+            .padding(.horizontal, 11).frame(height: 38)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(OMWColor.fillTertiary.opacity(0.0001))   // hit area
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!clickable)
+        .opacity(clickable ? 1 : 0.55)
+    }
+
+    private var dotColor: Color {
+        switch file.status {
+        case .modified: OMWColor.sysOrange
+        case .new: OMWColor.sysGreen
+        case .identical: OMWColor.labelQuaternary
+        }
+    }
+}
+
+/// GitHub-style unified diff: line-number gutters · +/− sign · code, red/green tinted.
+/// Binary files (no line preview) show a placeholder instead.
+private struct UnifiedDiffView: View {
+    let file: CopiedFile
+
+    var body: some View {
+        if file.isBinary {
+            HStack(spacing: 7) {
+                Image(systemName: "doc.badge.gearshape").font(.system(size: 13))
+                Text("Binary file — no preview").font(.system(size: 12, weight: .medium))
+            }
+            .foregroundStyle(OMWColor.labelTertiary)
+            .frame(maxWidth: .infinity).padding(.vertical, 36)
+            .background(OMWColor.fillQuaternary, in: RoundedRectangle(cornerRadius: OMWRadius.md))
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(file.lines) { line in row(line) }
+                }
+            }
+            .frame(maxHeight: 380)
+            .overlay(RoundedRectangle(cornerRadius: OMWRadius.md).strokeBorder(OMWColor.separator, lineWidth: 0.5))
+            .clipShape(RoundedRectangle(cornerRadius: OMWRadius.md))
+        }
+    }
+
+    private func row(_ line: DiffLine) -> some View {
+        HStack(spacing: 0) {
+            gutter(line.lineA)
+            gutter(line.lineB).overlay(alignment: .trailing) {
+                Rectangle().fill(OMWColor.separator).frame(width: 0.5)
+            }
+            Text(sign(line.kind)).frame(width: 16).foregroundStyle(signColor(line.kind))
+            Text(line.text.isEmpty ? " " : line.text)
+                .foregroundStyle(OMWColor.labelPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.trailing, 10).padding(.leading, 5)
+        }
+        .font(.omwMono(11))
+        .padding(.vertical, 1)
+        .background(rowBackground(line.kind))
+    }
+
+    private func gutter(_ n: Int?) -> some View {
+        Text(n.map(String.init) ?? "")
+            .font(.omwMono(10)).foregroundStyle(OMWColor.labelQuaternary)
+            .frame(width: 34, alignment: .trailing).padding(.trailing, 6)
+    }
+
+    private func sign(_ kind: DiffLine.Kind) -> String {
+        switch kind { case .add: "+"; case .del: "−"; case .context: "" }
+    }
+    private func signColor(_ kind: DiffLine.Kind) -> Color {
+        switch kind { case .add: OMWColor.sysGreen; case .del: OMWColor.sysRed; case .context: OMWColor.labelTertiary }
+    }
+    private func rowBackground(_ kind: DiffLine.Kind) -> Color {
+        switch kind {
+        case .add: OMWColor.sysGreen.opacity(0.13)
+        case .del: OMWColor.sysRed.opacity(0.12)
+        case .context: Color.clear
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED. (Not presented anywhere yet — wired in Task 8.)
+
+- [ ] **Step 3: Run swiftlint**
+
+Run: `swiftlint lint --quiet OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift`
+Expected: no violations. (If a type-length/line-length warning appears, split `UnifiedDiffView`
+into its own file `OhMyWorktree/Views/Detail/UnifiedDiffView.swift` and re-run.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift
+git commit -m "feat: CopiedFilesBrowser sheet with drill-in unified diff"
+```
+
+---
+
+### Task 8: Wire everything (DetailPane callbacks · browser presentation · apply alert · toast)
+
+Connect the section's callbacks to the view model, present the browser in `modalOverlay`, add the
+apply confirmation alert and the success toast.
+
+**Files:**
+- Create: `OhMyWorktree/Views/Detail/CopiedToast.swift`
+- Modify: `OhMyWorktree/Views/Detail/DetailPaneView.swift`
+- Modify: `OhMyWorktree/Views/ContentView.swift`
+
+- [ ] **Step 1: Create the toast view**
+
+Create `OhMyWorktree/Views/Detail/CopiedToast.swift`:
+
+```swift
+import SwiftUI
+
+/// A transient success pill pinned near the bottom of the window. Auto-dismisses
+/// ~2.4s after `message` becomes non-nil by clearing the binding.
+struct CopiedToast: View {
+    @Binding var message: String?
+
+    var body: some View {
+        VStack {
+            Spacer()
+            if let message {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(OMWColor.sysGreen)
+                    Text(message).font(.system(size: 12, weight: .medium)).foregroundStyle(OMWColor.labelPrimary)
+                }
+                .padding(.horizontal, 14).padding(.vertical, 9)
+                .glassEffect(.regular, in: Capsule())
+                .shadow(color: .black.opacity(0.28), radius: 16, y: 8)
+                .padding(.bottom, 46)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .task(id: message) {
+                    try? await Task.sleep(for: .seconds(2.4))
+                    self.message = nil
+                }
+            }
+        }
+        .animation(.spring(response: 0.34, dampingFraction: 0.86), value: message)
+        .allowsHitTesting(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 2: Forward callbacks through `DetailPaneView`**
+
+In `OhMyWorktree/Views/Detail/DetailPaneView.swift`, add two stored properties after
+`var onOpenPR: () -> Void` (line 20):
+
+```swift
+    var onOpenCopiedDiff: (CopiedFile) -> Void = { _ in }
+    var onBrowseCopied: () -> Void = {}
+```
+
+Then replace the copied-files line in `content(_:)` (line 71-73):
+
+```swift
+            if let copied = detail?.copiedFiles, !copied.isEmpty {
+                CopiedFilesSection(files: copied)
+            }
+```
+
+with:
+
+```swift
+            if let copied = detail?.copiedFiles, !copied.isEmpty {
+                CopiedFilesSection(files: copied, onOpenDiff: onOpenCopiedDiff, onBrowseAll: onBrowseCopied)
+            }
+```
+
+- [ ] **Step 3: Pass view-model handlers from `ContentView`**
+
+In `OhMyWorktree/Views/ContentView.swift`, in `worktreeColumns`, extend the `DetailPaneView(...)`
+call (lines 151-161) by adding these two arguments after the `onOpenPR:` closure:
+
+```swift
+            onOpenCopiedDiff: { file in
+                if let wt = selectedWorktree { worktreeViewModel.openCopiedDiff(file, for: wt) }
+            },
+            onBrowseCopied: {
+                if let wt = selectedWorktree { worktreeViewModel.browseCopiedFiles(for: wt) }
+            }
+```
+
+- [ ] **Step 4: Present the browser in `modalOverlay`**
+
+In `OhMyWorktree/Views/ContentView.swift`, add a branch to `modalOverlay` (after the
+`isShowingImportPR` branch, before `modalOverlay`'s closing brace, around line 252):
+
+```swift
+        } else if let browser = worktreeViewModel.copiedBrowser {
+            glassModal {
+                CopiedFilesBrowser(
+                    files: worktreeViewModel.selectedWorktreeDetail?.copiedFiles ?? [],
+                    focusedPath: Binding(
+                        get: { worktreeViewModel.copiedBrowser?.focusedPath },
+                        set: { worktreeViewModel.copiedBrowser?.focusedPath = $0 }
+                    ),
+                    onApply: { file in worktreeViewModel.pendingApply = file },
+                    onClose: { worktreeViewModel.copiedBrowser = nil }
+                )
+                .environment(\.omwAccent, accent)
+                .id(browser.worktree.id)
+            }
+        }
+```
+
+- [ ] **Step 5: Add the toast overlay**
+
+In `OhMyWorktree/Views/ContentView.swift`, inside the top-level `ZStack` in `body`, add
+`CopiedToast` after `modalOverlay` (line 30):
+
+```swift
+            CopiedToast(message: Binding(
+                get: { worktreeViewModel.copiedToast },
+                set: { worktreeViewModel.copiedToast = $0 }
+            ))
+            .zIndex(30)
+```
+
+- [ ] **Step 6: Add the apply-confirmation alert**
+
+In `OhMyWorktree/Views/ContentView.swift`, after the existing `repoPendingRemoval` `.alert`
+(ends ~line 91), add another `.alert`:
+
+```swift
+        .alert(
+            worktreeViewModel.pendingApply.map { "Apply \(($0.path as NSString).lastPathComponent) to main?" } ?? "",
+            isPresented: Binding(
+                get: { worktreeViewModel.pendingApply != nil },
+                set: { if !$0 { worktreeViewModel.pendingApply = nil } }
+            ),
+            presenting: worktreeViewModel.pendingApply
+        ) { file in
+            Button(file.status == .new ? "Copy to main" : "Apply to main", role: .destructive) {
+                let target = worktreeViewModel.copiedBrowser?.worktree
+                worktreeViewModel.pendingApply = nil
+                if let target {
+                    Task { await worktreeViewModel.applyCopiedFileToMain(file, in: target) }
+                }
+            }
+            Button("Cancel", role: .cancel) { worktreeViewModel.pendingApply = nil }
+        } message: { file in
+            Text("Overwrites main’s local copy of \(file.path) with this worktree’s version. "
+                + "This updates the file on disk only — nothing is committed to Git.")
+        }
+```
+
+- [ ] **Step 7: Build and run the full test scheme**
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktree -destination 'platform=macOS' build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED.
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | tail -10`
+Expected: all suites PASS.
+
+- [ ] **Step 8: swiftlint**
+
+Run: `swiftlint lint --quiet OhMyWorktree/Views/ContentView.swift OhMyWorktree/Views/Detail/DetailPaneView.swift OhMyWorktree/Views/Detail/CopiedToast.swift`
+Expected: no violations.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add OhMyWorktree/Views/Detail/CopiedToast.swift \
+        OhMyWorktree/Views/Detail/DetailPaneView.swift \
+        OhMyWorktree/Views/ContentView.swift
+git commit -m "feat: wire copied-files browser, apply alert, and toast"
+```
+
+---
+
+### Task 9: Coverage gate + final verification
+
+- [ ] **Step 1: Run the coverage gate**
+
+Run: `scripts/coverage.sh`
+Expected: PASS. The new `Models/LineDiff.swift`, `Models/CopiedFile.swift`, and
+`Services/CopiedFileDiffer.swift` must each report 100%. If any line is uncovered, add a test
+case for it (do NOT add to `coverage-exclude.txt`). New `Views/**` files are already excluded.
+
+- [ ] **Step 2: Full lint + test (pre-commit gate from CLAUDE.md)**
+
+Run: `swiftlint lint`
+Expected: no violations.
+
+Run: `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests -destination 'platform=macOS' test 2>&1 | tail -10`
+Expected: TEST SUCCEEDED.
+
+- [ ] **Step 3: Manual smoke (record results)**
+
+Build & run the app. With a repo that has a `feature/*` worktree containing copied `.env`/config files:
+1. Edit a copied `.env` in the worktree so it differs from the repo copy.
+2. Reselect the worktree → its chip shows an orange dot + `+N −N`; header shows `· M changed`.
+3. Click the changed chip → browser opens straight to that file's unified diff.
+4. `‹ All files` → list; type in Filter; toggle `Changed only`.
+5. Open a `new` file (in worktree, not in repo) → diff shows all-adds, button says `Copy to main`.
+6. `Apply to main` → confirmation alert → confirm → toast appears, browser returns to list, the
+   row/chip flips to `identical`; verify the repo's copy now matches on disk.
+7. `Esc` from the list closes the sheet.
+
+- [ ] **Step 4: Final commit (if any smoke fixes were needed)**
+
+```bash
+git add -A
+git commit -m "test: verify copied-files diff coverage + smoke fixes"
+```
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** status model (T2) · LCS diff (T1) · differ compare/apply (T3) · model type
+  change + load (T4) · VM state/glue (T5) · diff-aware section + PathLabel (T6) · browser sheet +
+  unified diff + binary placeholder (T7) · presentation + apply alert + toast (T8) · 100% gate +
+  smoke (T9). Binary handling: T2 `classify*Binary` + T7 `UnifiedDiffView` placeholder. Long paths:
+  `PathLabel` (T6). Centered glass sheet: `.glassSheet()` + `glassModal` (T7/T8).
+- **Placeholder scan:** none — every code step contains full code.
+- **Type consistency:** `CopiedFileStatus{identical,modified,new}` + `isBinary` used identically in
+  T2/T4/T6/T7; `CopiedFile.classify(path:mainData:worktreeData:)`, `CopiedFileDiffer.compare(relativePaths:worktreePath:repositoryPath:)`
+  / `applyToMain(_:worktreePath:repositoryPath:)`, and VM `browseCopiedFiles`/`openCopiedDiff`/
+  `applyCopiedFileToMain`/`copiedBrowser`/`pendingApply`/`copiedToast` are referenced consistently
+  across tasks.
+```

--- a/docs/superpowers/specs/2026-06-08-copied-files-diff-design.md
+++ b/docs/superpowers/specs/2026-06-08-copied-files-diff-design.md
@@ -1,0 +1,275 @@
+# Copied Files Diff & Apply-to-Main Design
+
+## Context
+
+When a worktree is created, `WorktreeFileCopier` copies git-ignored local files
+(`.env*`, local configs matched by `.worktreeinclude`) **from the repository root
+(the main worktree) into the new worktree**. After creation those copies drift:
+the worktree's `.env` gets edited while the repository's copy stays behind.
+
+Today the detail pane's **Copied files** section (`CopiedFilesSection`) only lists
+file *names* (`WorktreeDetail.copiedFiles: [String]`) with an inline expand/filter.
+It cannot tell whether a copy still matches main, show what changed, or push a
+change back.
+
+This feature, prototyped in the Claude Design handoff bundle
+(`oh-my-worktree/project/`, chat transcript `chats/chat6.md`), makes the copied
+files **diff-aware** and adds a **searchable browser sheet** that drills into a
+GitHub-style unified diff and can **apply a copy back to main**.
+
+The prototype is HTML/CSS/JS. The job is to recreate its visual + interaction
+output in this SwiftUI app, not to copy its structure. The authoritative prototype
+sources are `data.jsx` (`diffLines`, `CF`, `fileStatus`), `WorktreeWindow.jsx`
+(`CopiedFiles`, `PathLabel`), `Sheets.jsx` (`CopiedFilesSheet`, `DiffBody`,
+`CopiedFileRow`), and `omw.css` (`.cf-*`, `.fpop-*`, `.files-pop`, `.dl-*`, `.pl`).
+
+## Approved Decisions
+
+Confirmed with the user before this spec:
+
+1. **Scope:** build the full feature in one branch (diff-aware chips + searchable
+   browser sheet + drill-in diff + Apply-to-main), test-first.
+2. **Binary / non-text files:** detect non-UTF-8 content; compare by bytes for
+   status (`identical` vs `modified`); show "Binary — no preview" instead of a
+   line diff; still allow Copy/Apply to main.
+3. **Presentation:** a centered modal **glass sheet** (the app's existing
+   `modalOverlay` + `glassModal` + `.glassSheet()` pattern), matching the
+   prototype's centered `.files-pop` card. Not an anchored popover.
+
+Additional defaults (from the prototype, not separately asked):
+
+- **"main" = the repository root path** (`repository.path`). Worktree files are
+  compared against, and applied back to, `repository.path/<relativePath>`.
+- **Apply direction is worktree → main, whole-file.** No line-level/hunk apply, no
+  bidirectional (main → worktree) revert. The assistant offered both in chat6;
+  the user did not take them. Out of scope here.
+- **Apply touches only the on-disk local copy. Nothing is staged or committed to
+  Git.** A confirmation dialog precedes every overwrite.
+
+## Scope
+
+In scope:
+
+- New tested model + logic units: `CopiedFileStatus`, `DiffLine`, `CopiedFile`,
+  `LineDiff` (LCS line diff), `CopiedPath` (path split helper).
+- New tested service `CopiedFileDiffer`: build `[CopiedFile]` by comparing each
+  copied path's worktree vs repository content; apply a file back to main.
+- Change `WorktreeDetail.copiedFiles` from `[String]` to `[CopiedFile]`; populate
+  it in `WorktreeListViewModel.loadDetail`.
+- Rewrite `CopiedFilesSection` to be diff-aware (status header + status chips +
+  "View all" affordance).
+- New view `CopiedFilesBrowser` (one glass sheet, list ↔ diff drill-in) plus
+  `CopiedFileRow`, `UnifiedDiffView`, `PathLabel` subviews.
+- Apply confirmation dialog (native `.alert`, matching `WorktreeRemovalDialogs`)
+  and a success toast.
+- Thin `WorktreeListViewModel` glue: browser open/close + drilled-in file state,
+  `applyCopiedFileToMain`, post-apply detail reload + toast.
+- Wire the browser into `ContentView.modalOverlay`; pass open handlers down through
+  `DetailPaneView` → `CopiedFilesSection`.
+- Full unit tests for every new Models/Services unit; update `WorktreeDetailTests`.
+
+Out of scope:
+
+- Line-level / per-hunk apply; bidirectional revert (main → worktree).
+- Any Git staging/commit/stash of applied changes.
+- Diffing tracked files or the worktree's own `git diff` (already shown by
+  "Changes vs. base").
+- Watching files for live diff refresh; status is computed on detail (re)load.
+- Reworking the detail pane beyond the Copied files section.
+
+## Architecture
+
+Coverage rule that drives the split (see
+`2026-06-03-coverage-100-gate-design.md` and `coverage-exclude.txt`):
+`OhMyWorktree/Views/**` is **excluded** from the 100% gate; view models are in the
+flaky quarantine. Therefore **all behavior lives in `Models/` + `Services/`
+(100% tested), all rendering lives in `Views/` (excluded).** No new untested logic
+may live in a view or view-model body.
+
+### Models (new, in `OhMyWorktree/Models/`, 100% tested)
+
+```
+enum CopiedFileStatus: Sendable, Equatable {
+    case identical          // text, same bytes
+    case modified           // text, differs (has line diff)
+    case new                // present in worktree, absent in main
+    case binaryIdentical    // non-UTF-8, same bytes
+    case binaryModified     // non-UTF-8, differs
+
+    var isChanged: Bool     // modified | new | binaryModified
+    var isClickable: Bool   // anything with something to show/apply (not identical/binaryIdentical)
+    var sortRank: Int       // changed(0) < new(1) < identical(2), for list/chip ordering
+}
+
+struct DiffLine: Sendable, Equatable, Identifiable {
+    enum Kind: Sendable { case context, add, del }
+    let kind: Kind
+    let text: String
+    let lineA: Int?         // line number on the main side (nil for adds)
+    let lineB: Int?         // line number on the worktree side (nil for dels)
+    var id: Int             // stable index assigned at build time
+}
+
+struct CopiedFile: Sendable, Equatable, Identifiable {
+    let path: String        // repo-relative path
+    let status: CopiedFileStatus
+    let added: Int
+    let removed: Int
+    let isBinary: Bool
+    let mainContent: String?      // nil when new or binary
+    let worktreeContent: String?  // nil when binary
+    var id: String { path }
+    var lines: [DiffLine]   // built once; empty for identical/binary
+}
+```
+
+`CopiedPath.split(_ path:) -> (dir: String, base: String)` — directory (incl.
+trailing `/`) and filename; powers `PathLabel`'s truncate-dir/keep-filename layout.
+
+### Diff algorithm (new, `OhMyWorktree/Models/LineDiff.swift`, 100% tested)
+
+Port of `data.jsx#diffLines` — an LCS-table line diff:
+
+- Split both sides on `"\n"`.
+- One side empty → all adds / all dels.
+- Otherwise fill the `(n+1)×(m+1)` LCS length table, then walk it: equal → context,
+  prefer del when `dp[i+1][j] >= dp[i][j+1]`, else add; drain the tails.
+- Return `[DiffLine]` with 1-based `lineA`/`lineB` assigned as in the prototype.
+
+`added` / `removed` counts = number of `add` / `del` lines.
+
+### Service (new, `OhMyWorktree/Services/CopiedFileDiffer.swift`, 100% tested)
+
+```
+final class CopiedFileDiffer: Sendable {
+    func compare(relativePaths: [String],
+                 worktreePath: String,
+                 repositoryPath: String) -> [CopiedFile]
+    func applyToMain(_ file: CopiedFile,
+                     worktreePath: String,
+                     repositoryPath: String) throws
+}
+```
+
+`compare`:
+- For each relative path, read `worktreePath/<p>` and `repositoryPath/<p>` as `Data`.
+- Worktree data present, repo data absent → `.new` (added = worktree line count).
+- Both present, bytes equal → `.identical` (or `.binaryIdentical` if non-UTF-8).
+- Both present, bytes differ:
+  - both decode as UTF-8 → `.modified` + `LineDiff` + counts.
+  - either is non-UTF-8 → `.binaryModified`, `isBinary = true`, no lines.
+- Worktree data absent → skip (the copied-files list comes from scanning the
+  worktree, so this should not happen; defensively omit).
+- Result sorted by `(status.sortRank, path)`.
+
+`applyToMain` (whole-file, worktree → repo):
+- Source = `worktreePath/<p>`, dest = `repositoryPath/<p>`.
+- Create dest parent dir (`withIntermediateDirectories: true`).
+- Write the worktree bytes to a temp file in the destination directory, then place
+  it: `replaceItemAt(dest, withItemAt: temp)` when dest exists, else `moveItem`.
+  This makes the overwrite atomic so a crash can't truncate main's copy.
+- Throw on read/write failure; the VM surfaces it via the existing error alert.
+
+Reads/writes use `FileManager` exactly like `WorktreeFileCopier`, and are tested
+with temp directories (the `WorktreeFileCopierTests` pattern already reaches 100%).
+
+### View model glue (`WorktreeListViewModel`, excluded; keep thin)
+
+- `loadDetail` calls `differ.compare(...)` (off the main actor via
+  `Task.detached`, like the existing `includedFiles` call) and assigns
+  `detail.copiedFiles`.
+- New state: `copiedBrowser: CopiedBrowserState?` (which worktree's files + the
+  drilled-in file, or nil = closed); `pendingApply: CopiedFile?`;
+  `copiedToast: String?`.
+- `applyCopiedFileToMain(_:)`: call `differ.applyToMain(...)`, then reload detail
+  (recompute statuses) and set the toast. All real work is in the tested service;
+  the VM is glue.
+
+### Views (new/changed, `OhMyWorktree/Views/**`, excluded)
+
+- `CopiedFilesSection` (rewrite): one-line header
+  `Copied files {N}` + `· {M} changed` (orange) + `.worktreeinclude`; status chips
+  (sorted, cap 5) — modified = orange dot + `+N −N`, new = green dot + `new`,
+  identical = `doc` glyph dimmed; `View all {N} files` when `N > 5`. Clicking a
+  changed chip opens the browser straight to that file's diff; "View all" opens the
+  list. Uses `FlowLayout` + `PathLabel`.
+- `CopiedFilesBrowser` (new): the `.glassSheet()` content. Two modes:
+  - **List:** title `Copied files {N} · {M} changed vs. main`; search field
+    ("Filter files…") + `Changed only` toggle (accent when on); scrollable
+    `CopiedFileRow`s; footer hint + `Done`.
+  - **Diff (drill-in):** `‹ All files` back button, `comparing vs. main` /
+    `new file — not in main`; `PathLabel` title; `UnifiedDiffView` (or the binary
+    placeholder); footer hint "Updates main's local copy only — nothing is
+    committed to Git." + `Apply to main` / `Copy to main`.
+  - Esc: diff → list, list → close (in-view `onExitCommand`/keyboard handling).
+- `CopiedFileRow`, `UnifiedDiffView` (line-numbered red/green rows from
+  `[DiffLine]`; binary placeholder), `PathLabel` (truncate dir, keep filename,
+  full path as `.help` tooltip).
+
+### Presentation & wiring
+
+- Add a `copiedBrowser` branch to `ContentView.modalOverlay`, wrapped in the
+  existing `glassModal { CopiedFilesBrowser(...).glassSheet() }`.
+- Apply confirmation: a `.alert` on `ContentView` driven by `pendingApply`
+  (destructive "Apply to main" + Cancel), worded like `WorktreeRemovalDialogs`
+  ("Overwrites main's local copy of <file>. This is not committed to Git.").
+- Toast: a small transient overlay bound to `copiedToast`, auto-dismissing.
+- `DetailPaneView` gains `onOpenCopiedDiff: (CopiedFile) -> Void` and
+  `onBrowseCopied: () -> Void`, forwarded to `CopiedFilesSection`.
+
+## Visual reference (from `omw.css`)
+
+- Status colors: modified `--sys-orange`, new `--sys-green`, add line bg
+  green@13%, del line bg red@12%; counts `+` green / `−` red.
+  All map to existing `OMWColor.sysOrange/.sysGreen/.sysRed` and label tiers.
+- Chips: dot 6px; `chip-modified` = orange@15% over fill-tertiary; `chip-new` =
+  green@15%; `chip-same` opacity .48.
+- Diff rows (`.dl`): grid `34px 36px 16px 1fr` (lineA · lineB · sign · code),
+  mono, `white-space: pre-wrap`, max-height ~380.
+- Sheet (`.files-pop`): width 520, glass fill + blur, radius `--r-2xl`,
+  `sheet-in` entrance. Maps to `.glassSheet()` + `glassModal`.
+- `PathLabel` (`.pl`): `.pl-dir` ellipsis-truncates, `.pl-base` never shrinks.
+
+## Testing & Coverage
+
+100% line coverage on every new non-view file (the gate excludes `Views/**`).
+
+- `LineDiffTests`: identical, all-add (empty main / new), all-del (empty
+  worktree), single-line change, interleaved add/del, trailing newline, multi-line
+  blocks, line-number assignment, empty-vs-empty.
+- `CopiedFileTests` / `CopiedFileStatusTests`: status derivation incl. `new`,
+  `identical`, `modified`, binary variants; `isChanged`/`isClickable`/`sortRank`;
+  `added`/`removed`; `CopiedPath.split` (no slash, nested, trailing slash, dotfile).
+- `CopiedFileDifferTests` (temp dirs): new, identical, modified, binary identical,
+  binary modified; sort order; missing-in-main; `applyToMain` creating dirs,
+  overwriting an existing copy, copying a new file, and error on an unwritable
+  dest. Assert main's bytes equal the worktree's after apply, and that re-`compare`
+  reports `identical`.
+- `WorktreeDetailTests`: updated for `[CopiedFile]`, including `.empty`.
+
+Pre-commit (per CLAUDE.md): `swiftlint lint` and the test scheme must pass.
+
+## Verification
+
+- `swiftlint lint`
+- `xcodebuild -project OhMyWorktree.xcodeproj -scheme OhMyWorktreeTests \
+  -destination 'platform=macOS' test`
+- `scripts/coverage.sh` (100% gate; no new entries in `coverage-exclude.txt`)
+- Manual smoke: select `feature/*` worktree with copied files → modified chips show
+  `+N −N`; open browser, search + `Changed only`, drill into a diff, Apply to main
+  → confirm dialog → chip flips to identical + toast. New file shows `new` →
+  `Copy to main`.
+
+## Risks & Edge Cases
+
+- **Large/binary files:** reads load whole files into memory. Copied files are
+  small configs; acceptable. Binary path avoids line-diffing entirely.
+- **File deleted in worktree:** cannot occur — the list is derived by scanning the
+  worktree; defensively skipped in `compare`.
+- **Apply atomicity:** write-to-temp-then-replace prevents a partial overwrite of
+  main's copy.
+- **Symlinks / permissions:** `applyToMain` surfaces `FileManager` errors through
+  the existing error alert rather than failing silently.
+- **Path display:** very long monorepo paths handled by `PathLabel` truncation +
+  tooltip; no layout overflow (the prototype's original inline-expand bug).
+```


### PR DESCRIPTION
## Summary

Makes the detail pane's **Copied files** section diff-aware and lets you push a changed copy back to *main*:

- Each `.worktreeinclude` copy (`.env*`, local configs) is compared against the repository's (main worktree's) copy → **modified / new / identical**. Binary files are byte-compared with no line preview.
- Diff-aware chips: orange dot + `+N −N` (modified), green dot + `new`, dimmed `identical`, with a `· N changed` count and a **View all** affordance.
- A single searchable glass sheet (`CopiedFilesBrowser`) drills from the file list into a GitHub-style unified diff, and from the diff **Apply to main** / **Copy to main** overwrites main's local copy behind a confirmation, then shows a success toast and refreshes (the file flips to `identical`).
- **File edits are picked up by every existing refresh trigger** (app activation, ⌘R, toolbar, menu): reloading the worktree list now also refreshes the selected worktree's detail in place — including the debounced activation/menu path, which previously returned early inside its 2s window without recomputing. Previously diff statuses only recomputed on selection change, so editing a copied `.env` was never noticed.
- Long paths truncate the directory and keep the filename (full path on hover).

## Implementation notes

- **"main" = `repository.path`.** The diff is a *content* compare (these files are git-ignored, so `git diff` doesn't apply). Apply writes the worktree bytes to `repositoryPath/<relpath>` **atomically** — it updates the on-disk local copy only and **never touches Git**.
- New tested units (100% line coverage): `Models/LineDiff` (LCS line diff), `Models/CopiedFile` (status classification + path split), `Services/CopiedFileDiffer` (compare + applyToMain).
- `WorktreeDetail.copiedFiles` changed from `[String]` to `[CopiedFile]`, computed in `loadDetail`.
- `loadDetail` gained `clearingFirst:` — same-worktree refreshes (list reload, post-apply) keep the pane populated while recomputing, which also removes the post-apply flicker.
- Identical chips/rows dim via **color tier** (secondary filename, tertiary dir/dot) instead of whole-element opacity, and render as plain views rather than disabled buttons — the stacked opacity + disabled-button dim made them unreadable in light mode.
- New SwiftUI views live under `Views/Detail/**` (coverage-excluded by project policy): `CopiedFilesSection`, `PathLabel`, `CopiedFilesBrowser`, `CopiedFileRow`, `UnifiedDiffView`, `CopiedToast`, `CopiedFilesPresentation`.
- Design spec + step-by-step plan: `docs/superpowers/specs|plans/2026-06-08-copied-files-diff*`.

## Test plan

- [x] `swiftlint lint --strict` — 0 violations (131 files)
- [x] `xcodebuild ... -scheme OhMyWorktreeTests test` — 469 tests pass (incl. regression tests: editing a copied file then refreshing — via both the explicit `loadWorktrees()` path and the debounced path inside its 2s window — flips the status to `modified` without reselecting)
- [x] `scripts/coverage.sh` — strict 100% on 26 non-excluded files
- [x] App builds and launches cleanly (debug, isolated instance)
- [x] **Manual smoke (recommended):** select a `feature/*` worktree whose copied `.env` diverges from main → chip shows `+N −N` → click → unified diff → **Apply to main** → confirm → toast appears, chip flips to `identical`, and main's copy is updated on disk. Also verify: edit `.env` externally → switch back to the app (or ⌘R) → chip updates without reselecting. And a `new` file → **Copy to main**. Check identical chips/rows are readable in **light mode**.

## Known minor cosmetics (non-blocking)

- A zero-byte *new* file reports `+1`; a trailing newline shows a trailing blank diff line (matches the prototype). All counts remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)