### PR TITLE
Fix empty worktree list on first launch

### DIFF
--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -200,6 +200,19 @@ final class WorktreeListViewModel {
         await task.value
     }
 
+    /// Initial sync + load when the main window's content appears.
+    ///
+    /// On cold start, AppDelegate's selection observer syncs `repository`
+    /// before any window exists but intentionally does not load worktrees
+    /// (the status menu loads lazily on open), so `repository != nil` does
+    /// not imply the list has been loaded. Always reload for the current
+    /// selection here.
+    func windowAppeared(selectedRepository: Repository?) async {
+        guard let selectedRepository else { return }
+        repository = selectedRepository
+        await loadWorktrees()
+    }
+
     // MARK: - Load Helpers
 
     private func enriched(_ worktrees: [Worktree], metadata: [WorktreeMetadata]) async -> [Worktree] {

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -93,10 +93,7 @@ struct ContentView: View {
             if repoViewModel.repositories.isEmpty {
                 await repoViewModel.loadRepositories()
             }
-            if worktreeViewModel.repository == nil, let selected = repoViewModel.selectedRepository {
-                worktreeViewModel.repository = selected
-                await worktreeViewModel.loadWorktrees()
-            }
+            await worktreeViewModel.windowAppeared(selectedRepository: repoViewModel.selectedRepository)
         }
         .onChange(of: repoViewModel.selectedRepository) { _, newValue in
             Task {

--- a/OhMyWorktreeTests/WorktreeListViewModelTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelTests.swift
@@ -159,6 +159,57 @@ struct WorktreeListViewModelTests {
         #expect(sut.worktrees.count == 1)
     }
 
+    // MARK: - windowAppeared (cold start)
+
+    /// Regression (first-launch empty list): on cold start AppDelegate's
+    /// selection observer syncs `repository` before the main window exists,
+    /// intentionally WITHOUT loading worktrees (the status menu loads lazily).
+    /// The window's initial load must therefore not assume `repository != nil`
+    /// implies the list has been loaded.
+    @Test func windowAppeared_repositoryAlreadySynced_loadsWorktrees() async {
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/worktrees/feature-a
+        HEAD abc2222
+        branch refs/heads/feature/a
+
+        """)
+        // init() already synced sut.repository (= AppDelegate's sync); the
+        // list was never loaded — exactly the cold-start window-open state.
+        #expect(sut.worktrees.isEmpty)
+
+        await sut.windowAppeared(selectedRepository: testRepo)
+
+        #expect(sut.worktrees.count == 2)
+    }
+
+    @Test func windowAppeared_repositoryNotSet_syncsAndLoads() async {
+        sut.repository = nil
+        mockExecutor.stubWorktrees("""
+        worktree /tmp/test-repo
+        HEAD abc1111
+        branch refs/heads/main
+
+        """)
+
+        await sut.windowAppeared(selectedRepository: testRepo)
+
+        #expect(sut.repository?.id == testRepo.id)
+        #expect(sut.worktrees.count == 1)
+    }
+
+    @Test func windowAppeared_noSelection_keepsStateUntouched() async {
+        sut.repository = nil
+
+        await sut.windowAppeared(selectedRepository: nil)
+
+        #expect(sut.repository == nil)
+        #expect(sut.worktrees.isEmpty)
+    }
+
     // MARK: - renameWorktree
 
     @Test func renameWorktree_updatesLocalState() async {


### PR DESCRIPTION
## Problem

On first launch, the main window shows "No Worktrees" (0 count) for the selected repository. Switching to another repository loads the list correctly.

## Root cause

A cold-start ordering bug between three pieces that are individually correct:

1. At launch, `AppDelegate.observeSelectedRepository()` syncs `worktreeViewModel.repository` to the restored selection — intentionally **without** loading worktrees (the status menu loads lazily; pinned by `selectedRepoDoesNotEagerLoadWorktrees`).
2. When the main window later opens, ContentView's `.task` only loaded the list when `worktreeViewModel.repository == nil` — but step 1 already set it, so the initial load was skipped.
3. `.onChange(of: selectedRepository)` never fired either, because the selection happened before the view appeared.

Net effect: nothing ever loads the list until the user changes repositories. `repository != nil` does not imply the list has been loaded — the `.task` guard assumed it does.

## Fix

- New `WorktreeListViewModel.windowAppeared(selectedRepository:)`: always syncs the current selection and reloads when the window content appears.
- ContentView's `.task` delegates to it instead of the nil-guarded load.
- The AppDelegate sync contract is unchanged.

## Testing

- 3 new regression unit tests, including the key case: repository pre-synced (cold-start state) → `windowAppeared` must still load.
- Red→green was demonstrated against the real bug with a temporary window-hosting integration test: with the old ContentView wiring it times out (list stays empty for 5s after the window opens); with the fix it loads in ~0.2s. The integration test is not kept: `AppDelegateColdStartTests` has a pre-existing flaky AppKit `_NSWindowTransformAnimation` over-release crash (crash reports pre-date this change) that any added window-lifecycle test destabilizes — suite hardening is tracked separately.
- `swiftlint lint` clean, full suite (446 tests) green 3× consecutively, `scripts/coverage.sh` gate passes.
- Manually verified: worktrees now load on first launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)