### PR TITLE
Harden cold-start test suite against AppKit window-animation crash

### DIFF
--- a/OhMyWorktree/AppDelegate+Window.swift
+++ b/OhMyWorktree/AppDelegate+Window.swift
@@ -42,6 +42,14 @@ extension AppDelegate {
             defer: false
         )
         window.isReleasedWhenClosed = false
+        // Tests open and close windows far faster than the order-front
+        // transform animation completes; the in-flight animation then
+        // over-releases its window reference during a later autorelease-pool
+        // drain (_NSWindowTransformAnimation dealloc → SIGSEGV in the test
+        // runner). Disable window animations for the test process only.
+        if Self.isRunningTests {
+            window.animationBehavior = .none
+        }
         // Use a hosting *controller* (not a bare NSHostingView) so SwiftUI is
         // constrained to the window's content bounds and lays out correctly on
         // first show. A bare NSHostingView offers an unconstrained width on the

--- a/OhMyWorktreeTests/AppDelegateColdStartTests.swift
+++ b/OhMyWorktreeTests/AppDelegateColdStartTests.swift
@@ -226,6 +226,15 @@ final class AppDelegateColdStartTests {
             backing: .buffered,
             defer: false
         )
+        // Without this, close() also releases the window while ARC still
+        // holds this strong reference — the over-release detonates later in
+        // an autorelease-pool drain (the exact crash windowNotReleasedWhenClosed
+        // documents for the app). Disable the order-front animation too: the
+        // window closes ~0.1s after makeKeyAndOrderFront, well inside the
+        // animation, and the in-flight _NSWindowTransformAnimation would keep
+        // a reference into the dead window.
+        window.isReleasedWhenClosed = false
+        window.animationBehavior = .none
         defer { window.close() }
 
         let rootView = ContentView(
@@ -330,6 +339,72 @@ final class AppDelegateColdStartTests {
         // (ContentView and menuWillOpen are responsible for loading)
         #expect(worktreeVM.worktrees.isEmpty,
                "AppDelegate should not trigger worktree loading from selectedRepository sink")
+    }
+
+    // MARK: - Cold start: opening the window must load the pre-synced worktree list
+
+    /// Regression for the v2.0.4-era first-launch empty list (counterpart of
+    /// `selectedRepoDoesNotEagerLoadWorktrees`): on cold start the selection
+    /// observer syncs `worktreeViewModel.repository` before any window exists,
+    /// intentionally WITHOUT loading worktrees. When the main window then
+    /// opens, ContentView's initial load must still run — `repository != nil`
+    /// does not mean the list was ever loaded.
+    ///
+    /// Also serves as the window-lifecycle canary for this suite: it goes
+    /// through the production `showOrCreateMainWindow()` path, which is only
+    /// safe because window animations are disabled under test (see
+    /// `showOrCreateWindow`). See the PR for the crash analysis.
+    @Test func coldStart_windowOpen_loadsPreSyncedWorktreeList() async throws {
+        // A lingering main window from an earlier test would be reused by
+        // showOrCreateMainWindow and host the wrong view models. Wait for the
+        // suite deinit to close it and for AppKit to release it. Do NOT close
+        // it here: closing another test's window while its order-front
+        // animation could still be in flight is exactly the crash this suite
+        // is hardened against.
+        try await pollUntil {
+            !NSApp.windows.contains { $0.title == AppDelegate.mainWindowTitle }
+        }
+
+        let mockExecutor = MockSimpleGitExecutor()
+        mockExecutor.worktreeListOutput = """
+        worktree /tmp/cold-start-window-test
+        HEAD abc1111
+        branch refs/heads/main
+
+        worktree /tmp/cold-start-window-test/wt-feature
+        HEAD abc2222
+        branch refs/heads/feature/x
+
+        """
+
+        let worktreeVM = WorktreeListViewModel(
+            worktreeManager: WorktreeManager(executor: mockExecutor, fileManager: MockNoOpFileManager()),
+            store: .shared,
+            pullRequestService: MockNoPRService()
+        )
+        let repoVM = RepositoryListViewModel()
+
+        // Cold-start state right before the window opens: repositories loaded,
+        // selection restored, repository synced — but the list never loaded.
+        let repo = Repository(name: "cold-start-window-test", path: "/tmp/cold-start-window-test")
+        repoVM.repositories = [repo]
+        repoVM.selectedRepository = repo
+        worktreeVM.repository = repo
+        #expect(worktreeVM.worktrees.isEmpty)
+
+        let appDelegate = AppDelegate()
+        appDelegate.setupStatusItem()
+        appDelegate.repoViewModel = repoVM
+        appDelegate.worktreeViewModel = worktreeVM
+        appDelegate.shortcutStore = ShortcutStore()
+
+        // The production cold-start path: status item / hotkey / Dock reopen
+        // all open the window through here. The window is cleaned up by this
+        // suite's deinit (same as the other showOrCreateMainWindow tests).
+        appDelegate.showOrCreateMainWindow()
+
+        // ContentView's appearance must trigger the initial worktree load.
+        try await pollUntil { worktreeVM.worktrees.count == 2 }
     }
 
     // MARK: - Settings view does not impose a fixed size that conflicts with window


### PR DESCRIPTION
> [!NOTE]
> Stacked on #52 (the canary test exercises `windowAppeared` introduced there). When #52 merges, GitHub will retarget this PR to `main`.

## Problem

`AppDelegateColdStartTests` had a latent flaky SIGSEGV that made it reject any new window-lifecycle test: adding one such test crashed the suite in roughly 2 of 3 runs (3/3 with some variants), while the checked-in suite sat in a fragile 3/3-passing equilibrium. Matching crash reports from June 6 prove the bug pre-dates recent changes.

## Root cause

Crash signature (identical across all reports):

```
objc_release
-[_NSWindowTransformAnimation dealloc]
_Block_release ← -[NSConcretePointerArray dealloc]
AutoreleasePoolPage::releaseUntil → objc_autoreleasePoolPop
CA::Context::commit_transaction (AppKit stepIdle / stepTransactionFlush)
```

Tests open and close windows far faster (~0.1–0.3s) than the order-front transform animation completes. The in-flight `_NSWindowTransformAnimation` — kept alive by completion-block machinery in an autoreleased pointer array — holds a non-owning reference to the window. When the pool drains, the animation's dealloc releases a window that is already gone, and the crash is attributed to whichever test happens to be running at that drain, not the test that planted it.

Two compounding sources of a too-early-dead window:

1. `hostedContentViewCentersTrafficLightsInToolbar` created a manual `NSWindow` **without** `isReleasedWhenClosed = false` while holding a strong ARC reference and defer-closing it — `close()` performs an extra release, the over-release the app's own `windowNotReleasedWhenClosed` test warns about.
2. Windows created via `showOrCreateMainWindow()` / `showOrCreateSettingsWindow()` are closed by the suite's per-test `deinit` (or were closed by tests directly) well inside their order-front animation.

## Fix

- `showOrCreateWindow`: `window.animationBehavior = .none` **only when `AppDelegate.isRunningTests`** — no `_NSWindowTransformAnimation` is ever created in the test process; production behavior is unchanged.
- Traffic-lights test: `isReleasedWhenClosed = false` + `animationBehavior = .none`.
- Re-added the cold-start window-integration canary removed in #52: seeds the AppDelegate-pre-synced state, opens the window through the production `showOrCreateMainWindow()` path, and asserts ContentView's `.task` → `windowAppeared` loads the list (the first-launch empty-list regression).

## Verification

| Configuration | Full-suite result |
|---|---|
| Canary added, no hardening (red) | 0/3 — SIGSEGV, same signature |
| Canary + hardening (green) | **5/5 consecutive** (447 tests) |

`swiftlint lint` clean; `scripts/coverage.sh` strict gate passes (touched production file is in the AppDelegate coverage exclusion; behavior change is test-process-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)