### PR TITLE
Show update alert when checking from menu bar with no window open

### DIFF
--- a/OhMyWorktree/AppDelegate.swift
+++ b/OhMyWorktree/AppDelegate.swift
@@ -56,7 +56,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(
             DockPolicy.activationPolicy(
                 showInDock: UserDefaults.standard.bool(forKey: DockPolicy.defaultsKey),
-                hasAppWindows: false
+                hasAppWindows: false,
+                updaterSessionActive: false
             )
         )
         NSApp.appearance = AppearanceMode.named(

--- a/OhMyWorktree/Services/DockPolicy.swift
+++ b/OhMyWorktree/Services/DockPolicy.swift
@@ -1,27 +1,49 @@
 import AppKit
 
-/// Decides the app's Dock visibility (its activation policy) from the two inputs
-/// that affect it: whether the user pinned the Dock icon on, and whether a real
-/// app window is currently open.
+/// Decides the app's Dock visibility (its activation policy) from the three
+/// inputs that affect it: whether the user pinned the Dock icon on, whether a
+/// real app window is currently open, and whether a user-initiated Sparkle
+/// update session is running.
 ///
 /// The app is a menu-bar accessory by default. It must become `.regular` whenever
 /// a window is open (so Cmd+Tab and Cmd+` work) *and* whenever the user has opted
 /// to always show the Dock icon. Otherwise it stays `.accessory` (no Dock icon).
+///
+/// The updater input exists because Sparkle's result alerts ("You're up to
+/// date", errors) run as modal panels that `WindowObserver` deliberately does
+/// not count as app windows. Without it, the policy would snap back to
+/// `.accessory` the moment Sparkle's transient "Checking for updates…" window
+/// closes, deactivating the app and leaving the alert invisible behind other
+/// apps' windows (macOS 14+ cooperative activation will not re-activate).
 enum DockPolicy {
 
     /// `UserDefaults` / `@AppStorage` key backing the "Show icon in Dock" toggle.
     static let defaultsKey = "showInDock"
+
+    /// `userInfo` key carrying the Boolean session state in
+    /// `.updaterSessionStateChanged` notifications.
+    static let updaterSessionActiveKey = "updaterSessionActive"
 
     /// Resolves the activation policy the app should currently use.
     ///
     /// - Parameters:
     ///   - showInDock: the user's "Show icon in Dock" preference.
     ///   - hasAppWindows: whether a real app window is visible or miniaturized.
+    ///   - updaterSessionActive: whether a user-initiated update check is in
+    ///     progress (from click until Sparkle's update cycle finishes).
     /// - Returns: `.regular` when the Dock icon should show, otherwise `.accessory`.
     static func activationPolicy(
         showInDock: Bool,
-        hasAppWindows: Bool
+        hasAppWindows: Bool,
+        updaterSessionActive: Bool
     ) -> NSApplication.ActivationPolicy {
-        (showInDock || hasAppWindows) ? .regular : .accessory
+        (showInDock || hasAppWindows || updaterSessionActive) ? .regular : .accessory
+    }
+
+    /// Extracts the session state from a `.updaterSessionStateChanged`
+    /// notification's `userInfo`, defaulting to `false` for missing or
+    /// malformed payloads.
+    static func updaterSessionActive(from userInfo: [AnyHashable: Any]?) -> Bool {
+        userInfo?[updaterSessionActiveKey] as? Bool ?? false
     }
 }

--- a/OhMyWorktree/Services/UpdaterManager.swift
+++ b/OhMyWorktree/Services/UpdaterManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import Foundation
 import Observation
@@ -6,14 +7,21 @@ import Sparkle
 @Observable
 @MainActor
 final class UpdaterManager {
-    private let controller: SPUStandardUpdaterController
+    @ObservationIgnored private var controller: SPUStandardUpdaterController!
     var canCheckForUpdates = false
     @ObservationIgnored private var cancellable: AnyCancellable?
+    @ObservationIgnored private var sessionDelegate: UpdaterSessionDelegate?
 
     init() {
+        let sessionDelegate = UpdaterSessionDelegate {
+            // The update cycle is over (update installed/dismissed, no update
+            // found and alert acknowledged, error shown, or check cancelled).
+            Self.postUpdaterSessionState(active: false)
+        }
+        self.sessionDelegate = sessionDelegate
         controller = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: sessionDelegate,
             userDriverDelegate: nil
         )
         cancellable = controller.updater.publisher(for: \.canCheckForUpdates)
@@ -22,7 +30,18 @@ final class UpdaterManager {
             }
     }
 
+    /// Starts a user-initiated update check.
+    ///
+    /// The app is a menu-bar accessory while no window is open, so before
+    /// handing off to Sparkle this flags the session as active (which flips the
+    /// activation policy to `.regular` via `WindowObserver`) and activates the
+    /// app. Both must happen here, inside the user's click event, because
+    /// macOS 14+ cooperative activation only honors requests tied to a recent
+    /// user interaction — Sparkle's own later activation attempt is not enough,
+    /// and without this its windows and alerts open behind other apps.
     func checkForUpdates() {
+        Self.postUpdaterSessionState(active: true)
+        NSApp.activate(ignoringOtherApps: true)
         controller.checkForUpdates(nil)
     }
 
@@ -32,4 +51,42 @@ final class UpdaterManager {
             controller.updater.automaticallyChecksForUpdates = newValue
         }
     }
+
+    private static func postUpdaterSessionState(active: Bool) {
+        NotificationCenter.default.post(
+            name: .updaterSessionStateChanged,
+            object: nil,
+            userInfo: [DockPolicy.updaterSessionActiveKey: active]
+        )
+    }
+}
+
+/// Sparkle delegate that reports when an update cycle finishes. Kept separate
+/// from `UpdaterManager` so the manager stays a plain observable class; Sparkle
+/// holds its delegate weakly, so the manager retains this object.
+private final class UpdaterSessionDelegate: NSObject, SPUUpdaterDelegate {
+    private let onUpdateCycleFinished: @MainActor () -> Void
+
+    init(onUpdateCycleFinished: @escaping @MainActor () -> Void) {
+        self.onUpdateCycleFinished = onUpdateCycleFinished
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: Error?
+    ) {
+        // Sparkle invokes updater delegate callbacks on the main thread.
+        MainActor.assumeIsolated {
+            onUpdateCycleFinished()
+        }
+    }
+}
+
+extension Notification.Name {
+    /// Posted when a user-initiated Sparkle update session starts or ends, with
+    /// the state under `DockPolicy.updaterSessionActiveKey`. `WindowObserver`
+    /// keeps the app `.regular` while a session is active so Sparkle's modal
+    /// result alerts stay visible in front.
+    static let updaterSessionStateChanged = Notification.Name("com.ohmyworktree.updaterSessionStateChanged")
 }

--- a/OhMyWorktree/Services/WindowObserver.swift
+++ b/OhMyWorktree/Services/WindowObserver.swift
@@ -12,6 +12,12 @@ final class WindowObserver {
 
     private var isObserving = false
 
+    /// `true` from a user-initiated update check until Sparkle's update cycle
+    /// finishes. Sparkle's result alerts are modal panels that `isAppWindow`
+    /// deliberately ignores, so this flag is what keeps the app `.regular`
+    /// (and therefore the alert visible) for the duration of the session.
+    private var isUpdaterSessionActive = false
+
     func startObserving() {
         guard !isObserving else { return }
         isObserving = true
@@ -48,6 +54,12 @@ final class WindowObserver {
             name: .showInDockSettingChanged,
             object: nil
         )
+        center.addObserver(
+            self,
+            selector: #selector(updaterSessionStateChanged(_:)),
+            name: .updaterSessionStateChanged,
+            object: nil
+        )
     }
 
     // MARK: - Notification Handlers
@@ -79,6 +91,11 @@ final class WindowObserver {
         updateActivationPolicy()
     }
 
+    @objc private func updaterSessionStateChanged(_ notification: Notification) {
+        isUpdaterSessionActive = DockPolicy.updaterSessionActive(from: notification.userInfo)
+        updateActivationPolicy()
+    }
+
     // MARK: - Policy Management
 
     private func updateActivationPolicy() {
@@ -87,7 +104,11 @@ final class WindowObserver {
         }
 
         let showInDock = UserDefaults.standard.bool(forKey: DockPolicy.defaultsKey)
-        let desiredPolicy = DockPolicy.activationPolicy(showInDock: showInDock, hasAppWindows: hasAppWindows)
+        let desiredPolicy = DockPolicy.activationPolicy(
+            showInDock: showInDock,
+            hasAppWindows: hasAppWindows,
+            updaterSessionActive: isUpdaterSessionActive
+        )
         let currentPolicy = NSApp.activationPolicy()
 
         guard desiredPolicy != currentPolicy else { return }

--- a/OhMyWorktreeTests/DockPolicyTests.swift
+++ b/OhMyWorktreeTests/DockPolicyTests.swift
@@ -11,18 +11,78 @@ struct DockPolicyTests {
     }
 
     @Test func accessoryWhenIdleAndNotPinned() {
-        #expect(DockPolicy.activationPolicy(showInDock: false, hasAppWindows: false) == .accessory)
+        #expect(DockPolicy.activationPolicy(
+            showInDock: false, hasAppWindows: false, updaterSessionActive: false
+        ) == .accessory)
     }
 
     @Test func regularWhenPinnedEvenWithoutWindows() {
-        #expect(DockPolicy.activationPolicy(showInDock: true, hasAppWindows: false) == .regular)
+        #expect(DockPolicy.activationPolicy(
+            showInDock: true, hasAppWindows: false, updaterSessionActive: false
+        ) == .regular)
     }
 
     @Test func regularWhenWindowOpenEvenIfNotPinned() {
-        #expect(DockPolicy.activationPolicy(showInDock: false, hasAppWindows: true) == .regular)
+        #expect(DockPolicy.activationPolicy(
+            showInDock: false, hasAppWindows: true, updaterSessionActive: false
+        ) == .regular)
     }
 
     @Test func regularWhenPinnedAndWindowOpen() {
-        #expect(DockPolicy.activationPolicy(showInDock: true, hasAppWindows: true) == .regular)
+        #expect(DockPolicy.activationPolicy(
+            showInDock: true, hasAppWindows: true, updaterSessionActive: false
+        ) == .regular)
+    }
+
+    // MARK: - Updater session
+
+    /// A user-initiated update check must keep the app `.regular` even with no
+    /// windows open: Sparkle's "up to date" / error alerts otherwise end up
+    /// behind other apps when the policy reverts to `.accessory` mid-session.
+    @Test func regularDuringUpdaterSessionEvenWithoutWindows() {
+        #expect(DockPolicy.activationPolicy(
+            showInDock: false, hasAppWindows: false, updaterSessionActive: true
+        ) == .regular)
+    }
+
+    @Test func regularDuringUpdaterSessionWithWindowOpen() {
+        #expect(DockPolicy.activationPolicy(
+            showInDock: false, hasAppWindows: true, updaterSessionActive: true
+        ) == .regular)
+    }
+
+    @Test func accessoryAgainAfterUpdaterSessionEnds() {
+        #expect(DockPolicy.activationPolicy(
+            showInDock: false, hasAppWindows: false, updaterSessionActive: false
+        ) == .accessory)
+    }
+
+    // MARK: - Session-state notification payload
+
+    @Test func updaterSessionActiveKeyIsStable() {
+        #expect(DockPolicy.updaterSessionActiveKey == "updaterSessionActive")
+    }
+
+    @Test func updaterSessionActiveParsesTrue() {
+        let userInfo: [AnyHashable: Any] = [DockPolicy.updaterSessionActiveKey: true]
+        #expect(DockPolicy.updaterSessionActive(from: userInfo) == true)
+    }
+
+    @Test func updaterSessionActiveParsesFalse() {
+        let userInfo: [AnyHashable: Any] = [DockPolicy.updaterSessionActiveKey: false]
+        #expect(DockPolicy.updaterSessionActive(from: userInfo) == false)
+    }
+
+    @Test func updaterSessionActiveDefaultsToFalseWhenKeyMissing() {
+        #expect(DockPolicy.updaterSessionActive(from: [:]) == false)
+    }
+
+    @Test func updaterSessionActiveDefaultsToFalseWhenUserInfoNil() {
+        #expect(DockPolicy.updaterSessionActive(from: nil) == false)
+    }
+
+    @Test func updaterSessionActiveDefaultsToFalseWhenValueNotBool() {
+        let userInfo: [AnyHashable: Any] = [DockPolicy.updaterSessionActiveKey: "yes"]
+        #expect(DockPolicy.updaterSessionActive(from: userInfo) == false)
     }
 }


### PR DESCRIPTION
## Problem

When the app runs as a menu-bar accessory with **no window open**, clicking **Check for Updates** did nothing visible — no "Checking…" window, no "You're up to date" alert, no error.

## Root cause

Sparkle's `SPUStandardUserDriver` shows its "Checking…" status window and result alerts (up-to-date / errors) as transient panels. `WindowObserver.isAppWindow` deliberately does **not** count Sparkle's panels as app windows, so when the "Checking…" window closes, `WindowObserver` reverts the activation policy to `.accessory`. That **deactivates the app**, and on macOS 14+ cooperative activation (`NSApp.activate()`) will not refocus an app without a recent user interaction — so the result alert opens **behind** other apps' windows, invisible.

## Fix

Hold the app in `.regular` **and** activate it for the full duration of a user-initiated update session:

- **`DockPolicy.activationPolicy`** gains an `updaterSessionActive` input (→ `.regular` while a session runs), plus `updaterSessionActiveKey` and an `updaterSessionActive(from:)` notification-payload parser.
- **`UpdaterManager.checkForUpdates()`** posts `.updaterSessionStateChanged(active: true)` and calls `NSApp.activate(ignoringOtherApps:)` **inside the click event** (the activation must be tied to the user interaction — Sparkle's own later attempt is not enough). A private `UpdaterSessionDelegate` (`SPUUpdaterDelegate`) clears the session in `updater(_:didFinishUpdateCycleFor:error:)`; Sparkle holds the delegate weakly, so the manager retains it.
- **`WindowObserver`** observes the notification, tracks the session flag, and re-evaluates the activation policy.

## Verification

- **Live:** with no window open, **Check for Updates** now brings the app to front and shows the "You're up to date!" alert on top.
- ✅ Full unit suite (**481 tests**) passes
- ✅ SwiftLint clean
- ✅ 100% coverage gate passes — the new arg + parser are covered by `DockPolicyTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)