### PR TITLE
Fix intermittently reappearing main-window title

### DIFF
--- a/OhMyWorktree/AppDelegate+Window.swift
+++ b/OhMyWorktree/AppDelegate+Window.swift
@@ -54,7 +54,14 @@ extension AppDelegate {
         // constrained to the window's content bounds and lays out correctly on
         // first show. A bare NSHostingView offers an unconstrained width on the
         // initial pass, which makes the flexible column overflow the window.
-        window.contentViewController = NSHostingController(rootView: rootView())
+        let hosting = NSHostingController(rootView: rootView())
+        // This window's chrome is owned by AppKit (configureMainWindowChrome).
+        // Left enabled, SwiftUI's bar-appearance bridge re-asserts
+        // titleVisibility = .visible (bridging the content's navigationTitle)
+        // on async preference updates, racing our .hidden setting and
+        // intermittently revealing the title.
+        hosting.sceneBridgingOptions = []
+        window.contentViewController = hosting
         window.title = title
         configure?(window)
         window.setContentSize(size)


### PR DESCRIPTION
## Problem

The main window is supposed to show no titlebar title (the glass toolbar is the first content row under a transparent titlebar), but "Oh My Worktree" intermittently appeared next to the traffic lights — sometimes right after opening the window, and it persisted until app restart.

## Root cause

A last-writer-wins race between AppKit and SwiftUI on `NSWindow.titleVisibility`. An lldb breakpoint on `-[NSWindow setTitleVisibility:]` captured the sequence on the main window:

1. `NSHostingView.viewDidMoveToWindow` → SwiftUI `BarAppearanceBridge.updateWindowTitle` sets `.visible` (bridging ContentView's `.navigationTitle("Oh My Worktree")`)
2. `AppDelegate.configureMainWindowChrome` sets `.hidden` ✓
3. `MainWindowChromeConfigurator` probe re-applies `.hidden` ✓
4. **Async `NSHostingView.preferencesDidChange` (ViewGraph render) → `BarAppearanceBridge` sets `.visible` again** — final writer, title shows

`NSHostingController` bridges title/toolbar scene preferences to its host window by default, and the bridge re-runs on async preference updates (first layout, content loads, window tiling), so whether the title showed depended on whichever side wrote last. Cold-start window creation (launch → open window ~2s later) reproduced it 3/3.

## Fix

Set `sceneBridgingOptions = []` on the `NSHostingController` used for AppDelegate-managed windows, so AppKit stays the sole owner of the window chrome. `.navigationTitle` stays in ContentView for the WindowGroup path; the manual window's title string is already set via `window.title` for the title-based window lookup.

## Verification

- Cold-start repro protocol (launch → reopen at +2s → screenshot): 3/3 showed the title before the fix, 3/3 clean after
- `swiftlint lint` clean
- Full test suite: 473 tests in 44 suites pass
- `AppDelegate+*.swift` is on the coverage exclusion list, so the 100% gate is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)