### PR TITLE
Surface uncopied .worktreeinclude files as missing diffs

### DIFF
--- a/OhMyWorktree/Models/CopiedFile.swift
+++ b/OhMyWorktree/Models/CopiedFile.swift
@@ -5,17 +5,19 @@ enum CopiedFileStatus: Equatable, Sendable {
     case identical   // bytes equal
     case modified    // present in both, bytes differ
     case new         // present in the worktree, absent in main
+    case missing     // present in main, absent in the worktree (the copy never happened)
 
     /// Differs from main (anything worth surfacing / applying).
     var isChanged: Bool { self != .identical }
     /// Has something to open (a diff to view or content to copy back).
     var isClickable: Bool { self != .identical }
-    /// Ordering for chips/list: changed first, then new, then identical.
+    /// Ordering for chips/list: modified → missing → new → identical.
     var sortRank: Int {
         switch self {
         case .modified: 0
-        case .new: 1
-        case .identical: 2
+        case .missing: 1
+        case .new: 2
+        case .identical: 3
         }
     }
 }
@@ -42,9 +44,14 @@ struct CopiedFile: Equatable, Sendable, Identifiable {
 
     var id: String { path }
 
-    /// Classifies a copied file from raw bytes. `mainData == nil` ⇒ `.new`.
-    /// Non-UTF-8 on either side ⇒ binary (byte-compared, no line preview).
-    static func classify(path: String, mainData: Data?, worktreeData: Data) -> CopiedFile {
+    /// Classifies a copied file from raw bytes.
+    /// `worktreeData == nil` ⇒ `.missing` (in main, never copied into the worktree);
+    /// `mainData == nil` ⇒ `.new` (in the worktree, absent in main).
+    /// Non-UTF-8 on either present side ⇒ binary (byte-compared, no line preview).
+    static func classify(path: String, mainData: Data?, worktreeData: Data?) -> CopiedFile {
+        guard let worktreeData else {
+            return classifyMissing(path: path, mainData: mainData)
+        }
         let worktreeText = String(data: worktreeData, encoding: .utf8)
 
         guard let mainData else {
@@ -82,5 +89,20 @@ struct CopiedFile: Equatable, Sendable, Identifiable {
             removed: lines.filter { $0.kind == .del }.count,
             mainContent: mainText, worktreeContent: worktreeText, lines: lines
         )
+    }
+
+    /// A file present in main but absent from the worktree (the `.worktreeinclude`
+    /// copy never happened): main's content shown as removed lines, or a binary /
+    /// empty placeholder when main is non-UTF-8 or absent.
+    private static func classifyMissing(path: String, mainData: Data?) -> CopiedFile {
+        guard let mainData, let mainText = String(data: mainData, encoding: .utf8) else {
+            return CopiedFile(path: path, status: .missing, isBinary: mainData != nil,
+                              added: 0, removed: 0,
+                              mainContent: nil, worktreeContent: nil, lines: [])
+        }
+        let lines = LineDiff.compute(mainText, "")
+        return CopiedFile(path: path, status: .missing, isBinary: false,
+                          added: 0, removed: lines.count,
+                          mainContent: mainText, worktreeContent: nil, lines: lines)
     }
 }

--- a/OhMyWorktree/Services/CopiedFileDiffer.swift
+++ b/OhMyWorktree/Services/CopiedFileDiffer.swift
@@ -5,16 +5,19 @@ import Foundation
 /// Stateless; safe to instantiate per call.
 final class CopiedFileDiffer: Sendable {
 
-    /// Builds a `CopiedFile` per relative path by reading both copies.
-    /// Paths absent in the worktree are skipped (the list is derived from a
-    /// worktree scan, so this is defensive). Result is sorted changed → new → identical.
+    /// Builds a `CopiedFile` per relative path by reading both copies. A path may
+    /// live in either tree: present in main only ⇒ `.missing` (the copy never
+    /// happened); present in the worktree only ⇒ `.new`. Only paths absent on both
+    /// sides are skipped (defensive — the list is a union scan of both trees).
+    /// Result is sorted modified → missing → new → identical.
     func compare(relativePaths: [String], worktreePath: String, repositoryPath: String) -> [CopiedFile] {
         let fm = FileManager.default
         let files: [CopiedFile] = relativePaths.compactMap { rel in
             let worktreeFull = (worktreePath as NSString).appendingPathComponent(rel)
-            guard let worktreeData = fm.contents(atPath: worktreeFull) else { return nil }
             let mainFull = (repositoryPath as NSString).appendingPathComponent(rel)
+            let worktreeData = fm.contents(atPath: worktreeFull)
             let mainData = fm.contents(atPath: mainFull)
+            guard worktreeData != nil || mainData != nil else { return nil }
             return CopiedFile.classify(path: rel, mainData: mainData, worktreeData: worktreeData)
         }
         return files.sorted { lhs, rhs in
@@ -30,6 +33,20 @@ final class CopiedFileDiffer: Sendable {
         let fm = FileManager.default
         let source = URL(fileURLWithPath: (worktreePath as NSString).appendingPathComponent(file.path))
         let dest = URL(fileURLWithPath: (repositoryPath as NSString).appendingPathComponent(file.path))
+        let destDir = (dest.path as NSString).deletingLastPathComponent
+        try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true)
+        let data = try Data(contentsOf: source)
+        try data.write(to: dest, options: .atomic)
+    }
+
+    /// Copies main's local copy of `file` into the worktree (atomically; creates the
+    /// file and parent directories when absent). The inverse of `applyToMain`, for
+    /// `.missing` files — performs the `.worktreeinclude` copy that never ran. Never
+    /// touches Git.
+    func applyToWorktree(_ file: CopiedFile, worktreePath: String, repositoryPath: String) throws {
+        let fm = FileManager.default
+        let source = URL(fileURLWithPath: (repositoryPath as NSString).appendingPathComponent(file.path))
+        let dest = URL(fileURLWithPath: (worktreePath as NSString).appendingPathComponent(file.path))
         let destDir = (dest.path as NSString).deletingLastPathComponent
         try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true)
         let data = try Data(contentsOf: source)

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+CopiedFiles.swift
@@ -42,4 +42,24 @@ extension WorktreeListViewModel {
             errorMessage = error.localizedDescription
         }
     }
+
+    /// Copies `file` (main → worktree) to perform a `.worktreeinclude` copy that
+    /// never happened, reloads the detail so statuses refresh, and shows a toast.
+    /// Surfaces failures through the standard error alert.
+    func applyCopiedFileToWorktree(_ file: CopiedFile, in worktree: Worktree) async {
+        guard let repository else { return }
+        let differ = self.differ
+        let worktreePath = worktree.path
+        let repoPath = repository.path
+        do {
+            try await Task.detached {
+                try differ.applyToWorktree(file, worktreePath: worktreePath, repositoryPath: repoPath)
+            }.value
+            await loadDetail(for: worktree, clearingFirst: false)
+            copiedBrowser?.focusedPath = nil
+            copiedToast = "Copied \((file.path as NSString).lastPathComponent) to worktree"
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 }

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel+Creation.swift
@@ -101,7 +101,14 @@ extension WorktreeListViewModel {
         let differ = self.differ
         let path = worktree.path
         let repoPath = repository.path
-        let matches = await Task.detached { copier.includedFiles(in: path) }.value
+        // Candidate set = files matching `.worktreeinclude` in EITHER the worktree
+        // or main. One present only in main was never copied in (the copy was
+        // skipped, errored, or the worktree predates the pattern) — it must still
+        // surface, as `.missing`, rather than vanish from the diff.
+        let matches = await Task.detached {
+            Array(Set(copier.includedFiles(in: path))
+                .union(copier.includedFiles(in: repoPath))).sorted()
+        }.value
         // Only files Git ignores were actually copied; committed templates
         // (e.g. .env.example) come with the checkout and don't count.
         let ignored = await worktreeManager.gitIgnoredFiles(matches, worktreePath: path)

--- a/OhMyWorktree/Views/ContentView.swift
+++ b/OhMyWorktree/Views/ContentView.swift
@@ -262,6 +262,11 @@ struct ContentView: View {
                         set: { worktreeViewModel.copiedBrowser?.focusedPath = $0 }
                     ),
                     onApply: { file in worktreeViewModel.pendingApply = file },
+                    onApplyToWorktree: { file in
+                        if let target = worktreeViewModel.copiedBrowser?.worktree {
+                            Task { await worktreeViewModel.applyCopiedFileToWorktree(file, in: target) }
+                        }
+                    },
                     onClose: { worktreeViewModel.copiedBrowser = nil }
                 )
                 .environment(\.omwAccent, accent)

--- a/OhMyWorktree/Views/Detail/CopiedFileRow.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFileRow.swift
@@ -50,6 +50,9 @@ struct CopiedFileRow: View {
         case .new:
             Text("new").font(.system(size: 10, weight: .bold)).textCase(.uppercase)
                 .tracking(0.4).foregroundStyle(OMWColor.sysGreen)
+        case .missing:
+            Text("missing").font(.system(size: 10, weight: .bold)).textCase(.uppercase)
+                .tracking(0.4).foregroundStyle(OMWColor.sysRed)
         case .identical:
             Text("identical").font(.system(size: 10, weight: .medium))
                 .foregroundStyle(OMWColor.labelTertiary)
@@ -60,6 +63,7 @@ struct CopiedFileRow: View {
         switch file.status {
         case .modified: OMWColor.sysOrange
         case .new: OMWColor.sysGreen
+        case .missing: OMWColor.sysRed
         case .identical: OMWColor.labelTertiary
         }
     }

--- a/OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesBrowser.swift
@@ -7,6 +7,7 @@ struct CopiedFilesBrowser: View {
     let files: [CopiedFile]
     @Binding var focusedPath: String?
     var onApply: (CopiedFile) -> Void
+    var onApplyToWorktree: (CopiedFile) -> Void
     var onClose: () -> Void
 
     @Environment(\.omwAccent) private var accent
@@ -141,17 +142,36 @@ struct CopiedFilesBrowser: View {
                 .padding(.init(top: 8, leading: 18, bottom: 0, trailing: 18))
             UnifiedDiffView(file: file)
                 .padding(.init(top: 12, leading: 18, bottom: 4, trailing: 18))
-            footer(hint: "Updates main's local copy only — nothing is committed to Git.") {
-                Button { onApply(file) } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.left.to.line").font(.system(size: 13))
-                        Text(file.status == .new ? "Copy to main" : "Apply to main")
-                            .font(.system(size: 13, weight: .semibold))
-                    }
-                }
-                .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
-            }
+            footer(hint: applyHint(file)) { applyButton(file) }
         }
+    }
+
+    @ViewBuilder
+    private func applyButton(_ file: CopiedFile) -> some View {
+        if file.status == .missing {
+            Button { onApplyToWorktree(file) } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.right.to.line").font(.system(size: 13))
+                    Text("Copy to worktree").font(.system(size: 13, weight: .semibold))
+                }
+            }
+            .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
+        } else {
+            Button { onApply(file) } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.left.to.line").font(.system(size: 13))
+                    Text(file.status == .new ? "Copy to main" : "Apply to main")
+                        .font(.system(size: 13, weight: .semibold))
+                }
+            }
+            .buttonStyle(.borderedProminent).buttonBorderShape(.capsule).controlSize(.large)
+        }
+    }
+
+    private func applyHint(_ file: CopiedFile) -> String {
+        file.status == .missing
+            ? "Creates this file in the worktree from main's copy — nothing is committed to Git."
+            : "Updates main's local copy only — nothing is committed to Git."
     }
 
     private func diffHeader(_ file: CopiedFile) -> some View {
@@ -166,10 +186,18 @@ struct CopiedFilesBrowser: View {
             }
             .buttonStyle(.plain)
             Spacer()
-            Text(file.status == .new ? "new file — not in main" : "comparing vs. main")
+            Text(diffSubtitle(file))
                 .font(.omwMono(11)).foregroundStyle(OMWColor.labelQuaternary)
         }
         .padding(.init(top: 12, leading: 14, bottom: 0, trailing: 14))
+    }
+
+    private func diffSubtitle(_ file: CopiedFile) -> String {
+        switch file.status {
+        case .new: "new file — not in main"
+        case .missing: "missing here — exists in main"
+        default: "comparing vs. main"
+        }
     }
 
     // MARK: Footer

--- a/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
+++ b/OhMyWorktree/Views/Detail/CopiedFilesSection.swift
@@ -79,6 +79,7 @@ struct CopiedFilesSection: View {
             switch file.status {
             case .modified: Circle().fill(OMWColor.sysOrange).frame(width: 6, height: 6)
             case .new: Circle().fill(OMWColor.sysGreen).frame(width: 6, height: 6)
+            case .missing: Circle().fill(OMWColor.sysRed).frame(width: 6, height: 6)
             case .identical: Image(systemName: "doc").font(.system(size: 11))
             }
             PathLabel(path: file.path)
@@ -95,6 +96,12 @@ struct CopiedFilesSection: View {
                     .textCase(.uppercase)
                     .tracking(0.4)
                     .foregroundStyle(OMWColor.sysGreen)
+            } else if file.status == .missing {
+                Text("missing")
+                    .font(.system(size: 9, weight: .bold))
+                    .textCase(.uppercase)
+                    .tracking(0.4)
+                    .foregroundStyle(OMWColor.sysRed)
             }
         }
         .foregroundStyle(file.status == .identical ? OMWColor.labelSecondary : OMWColor.labelPrimary)
@@ -107,6 +114,7 @@ struct CopiedFilesSection: View {
         switch status {
         case .modified: OMWColor.sysOrange.opacity(0.15)
         case .new: OMWColor.sysGreen.opacity(0.15)
+        case .missing: OMWColor.sysRed.opacity(0.15)
         case .identical: OMWColor.fillTertiary
         }
     }

--- a/OhMyWorktreeTests/CopiedFileDifferTests.swift
+++ b/OhMyWorktreeTests/CopiedFileDifferTests.swift
@@ -56,11 +56,59 @@ final class CopiedFileDifferTests {
         #expect(files.map(\.status) == [.modified, .new, .identical])
     }
 
-    @Test func compareSkipsMissingWorktreeFile() {
-        write("ghost.env", in: repoDir, "A=1")   // exists in main, not in worktree
+    @Test func compareSurfacesMissingFileAsRemoved() {
+        // Exists in main, never copied into the worktree: it must surface as
+        // `.missing` showing main's content as removed lines — not be skipped.
+        write("ghost.env", in: repoDir, "A=1\nB=2")
         let files = sut.compare(relativePaths: ["ghost.env"],
                                 worktreePath: worktreeDir, repositoryPath: repoDir)
+        #expect(files.count == 1)
+        let file = files[0]
+        #expect(file.status == .missing)
+        #expect(file.isBinary == false)
+        #expect(file.added == 0)
+        #expect(file.removed == 2)
+        #expect(file.mainContent == "A=1\nB=2")
+        #expect(file.worktreeContent == nil)
+        #expect(file.lines.allSatisfy { $0.kind == .del })
+        #expect(file.status.isChanged && file.status.isClickable)
+    }
+
+    @Test func compareSurfacesMissingBinaryFile() {
+        write("blob.bin", in: repoDir, Data([0xFF, 0x00, 0xFE]))   // non-UTF-8, main only
+        let files = sut.compare(relativePaths: ["blob.bin"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+        #expect(files.first?.status == .missing)
+        #expect(files.first?.isBinary == true)
+        #expect(files.first?.lines.isEmpty == true)
+    }
+
+    @Test func compareSkipsPathAbsentOnBothSides() {
+        // Defensive: a candidate that exists in neither side is dropped entirely.
+        let files = sut.compare(relativePaths: ["nowhere.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
         #expect(files.isEmpty)
+    }
+
+    @Test func classifyBothNilIsMissingAndEmpty() {
+        let file = CopiedFile.classify(path: "x.env", mainData: nil, worktreeData: nil)
+        #expect(file.status == .missing)
+        #expect(file.isBinary == false)
+        #expect(file.lines.isEmpty)
+        #expect(file.mainContent == nil)
+        #expect(file.worktreeContent == nil)
+    }
+
+    @Test func compareSortsModifiedMissingNewIdentical() {
+        write("m.env", in: repoDir, "1"); write("m.env", in: worktreeDir, "2")        // modified
+        write("gone.env", in: repoDir, "x")                                           // missing
+        write("fresh.env", in: worktreeDir, "y")                                      // new
+        write("same.env", in: repoDir, "z"); write("same.env", in: worktreeDir, "z")  // identical
+
+        let files = sut.compare(relativePaths: ["same.env", "fresh.env", "gone.env", "m.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)
+        // sortRank: modified(0) → missing(1) → new(2) → identical(3)
+        #expect(files.map(\.status) == [.modified, .missing, .new, .identical])
     }
 
     @Test func compareDetectsBinaryModified() {
@@ -117,6 +165,32 @@ final class CopiedFileDifferTests {
                                worktreePath: worktreeDir, repositoryPath: repoDir)[0]
         #expect(throws: (any Error).self) {
             try sut.applyToMain(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+        }
+    }
+
+    // MARK: applyToWorktree (main → worktree, the reverse copy)
+
+    @Test func applyToWorktreeCopiesMainCopyCreatingDirs() throws {
+        write("config/local/app.env", in: repoDir, "K=V")   // main only → missing
+        let file = sut.compare(relativePaths: ["config/local/app.env"],
+                               worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(file.status == .missing)
+
+        try sut.applyToWorktree(file, worktreePath: worktreeDir, repositoryPath: repoDir)
+
+        #expect(read("config/local/app.env", in: worktreeDir) == Data("K=V".utf8))
+        // re-comparing now reports identical
+        let after = sut.compare(relativePaths: ["config/local/app.env"],
+                                worktreePath: worktreeDir, repositoryPath: repoDir)[0]
+        #expect(after.status == .identical)
+    }
+
+    @Test func applyToWorktreeThrowsWhenMainCopyMissing() {
+        let phantom = CopiedFile(path: "gone.env", status: .missing, isBinary: false,
+                                 added: 0, removed: 0, mainContent: nil,
+                                 worktreeContent: nil, lines: [])
+        #expect(throws: (any Error).self) {
+            try sut.applyToWorktree(phantom, worktreePath: worktreeDir, repositoryPath: repoDir)
         }
     }
 }

--- a/OhMyWorktreeTests/WorktreeListViewModelDetailRefreshTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelDetailRefreshTests.swift
@@ -97,6 +97,30 @@ final class WorktreeListViewModelDetailRefreshTests {
         #expect(sut.selectedWorktreeDetail == nil)
     }
 
+    /// Regression: a `.worktreeinclude` file present in main but never copied into
+    /// the worktree must surface as `.missing` (not vanish from the diff), and the
+    /// reverse copy must perform the skipped copy and flip it to identical.
+    @Test func uncopiedMainFileSurfacesAsMissingThenCopiesIntoWorktree() async {
+        write(".env", "A=1\nB=2", in: repoDir)   // main only — copy never happened
+        await sut.loadWorktrees()
+        guard let feature = sut.worktrees.first(where: { $0.path == wtDir }) else {
+            Issue.record("feature worktree missing from \(sut.worktrees.map(\.path))")
+            return
+        }
+        sut.selectedWorktreeIDs = [feature.id]
+        await sut.loadDetail(for: feature)
+        #expect(sut.selectedWorktreeDetail?.copiedFiles.map(\.status) == [.missing])
+
+        guard let missing = sut.selectedWorktreeDetail?.copiedFiles.first else {
+            Issue.record("missing file absent from detail")
+            return
+        }
+        await sut.applyCopiedFileToWorktree(missing, in: feature)
+        #expect(fm.contents(atPath: (wtDir as NSString).appendingPathComponent(".env"))
+            == Data("A=1\nB=2".utf8))
+        #expect(sut.selectedWorktreeDetail?.copiedFiles.map(\.status) == [.identical])
+    }
+
     @Test func debouncedLoadWorktreesStillRefreshesDetail() async {
         write(".env", "A=1", in: repoDir)
         write(".env", "A=1", in: wtDir)


### PR DESCRIPTION
## Problem

A `.worktreeinclude` file that exists in main but was never copied into a worktree showed **no diff at all** in the copied-files browser — even though that divergence is exactly what you'd want surfaced.

## Root cause

Three layers each dropped the file independently:

1. **Candidate list scanned the worktree only** — `loadDetail` derived the list from `includedFiles(in: worktreePath)`, so a file living only in main was never even a candidate.
2. **The differ skipped it** — `CopiedFileDiffer.compare` did `guard let worktreeData … else { return nil }`, dropping any path absent from the worktree. This was pinned by the old `compareSkipsMissingWorktreeFile` test.
3. **No model state for it** — `CopiedFileStatus` had only `.identical / .modified / .new` (new = worktree-only); nothing represented "present in main, absent from the worktree".

## Fix

- Add `CopiedFileStatus.missing`; `classify()` now takes optional worktree bytes and renders main's content as removed lines.
- `compare()` drops a path only when it is absent on **both** sides.
- `loadDetail` builds candidates from **worktree ∪ main**.
- Add `CopiedFileDiffer.applyToWorktree` + `applyCopiedFileToWorktree`, wired to a **"Copy to worktree"** action so the skipped copy can be performed in one click (the inverse of the existing "Apply to main").
- Render `.missing` across the section chips, browser row, and diff drill-in.

**Result:** uncopied files now appear as a red `missing` chip; clicking shows main's content as a removed (red) diff, and **Copy to worktree** performs the missing copy (→ flips to `identical`). Existing modified/new behaviour is unchanged.

## Testing

- 7 new `CopiedFileDiffer`/`classify` unit tests (missing text/binary, both-sides-absent, sort order, `applyToWorktree` success + throw).
- New end-to-end regression in `WorktreeListViewModelDetailRefreshTests`: a main-only `.env` surfaces as `[.missing]`, then `[.identical]` after Copy to worktree.
- Full suite: **489 tests pass**.
- Strict **100% coverage gate passes** (incl. changed `CopiedFile.swift` / `CopiedFileDiffer.swift`).
- SwiftLint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)