### PR TITLE
Fix dispatch thread-pool deadlock that froze worktree loading

### DIFF
--- a/OhMyWorktree/Services/GitCommandExecutor.swift
+++ b/OhMyWorktree/Services/GitCommandExecutor.swift
@@ -16,6 +16,26 @@ extension GitCommandExecuting {
     }
 }
 
+/// Thread-safe byte accumulator for a pipe. The stdout and stderr
+/// `readabilityHandler` callbacks fire on independent dispatch queues, so the
+/// buffer is guarded by a lock.
+private final class OutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    var collected: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+}
+
 /// Executes Git commands via Process. Thread-safe because it has no mutable state.
 final class GitCommandExecutor: GitCommandExecuting, Sendable {
     func execute(
@@ -43,47 +63,17 @@ final class GitCommandExecutor: GitCommandExecuting, Sendable {
             uniquingKeysWith: { _, new in new }
         )
 
-        // withTaskCancellationHandler ensures that when the enclosing Task is cancelled
-        // (e.g. by BackgroundTaskQueue's timeout), the spawned process receives SIGTERM
-        // instead of becoming a zombie that blocks waitUntilExit() indefinitely.
-        // The blocking work (run + waitUntilExit) is dispatched to a global queue so it
-        // never blocks the calling actor (e.g. MainActor).
+        // CRITICAL: this executor must never block a libdispatch worker thread.
+        // The previous implementation dispatched a worker onto the global pool and
+        // blocked it on `DispatchGroup.wait()` while waiting for two more pooled
+        // reader blocks — so 64+ concurrent calls parked every thread in the
+        // 64-thread global pool, and the reader blocks they waited on could never
+        // be scheduled. That deadlock froze "Loading worktrees…" forever. `run`
+        // (below) drains the pipes incrementally and resumes via
+        // `DispatchGroup.notify`, never `.wait()`, so the pool can't be exhausted.
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                DispatchQueue.global(qos: .userInitiated).async {
-                    do {
-                        try process.run()
-
-                        // Read both pipes concurrently to prevent deadlock.
-                        // If either pipe's buffer fills (~64KB on macOS), the child
-                        // blocks until it's drained. Sequential reads can deadlock
-                        // when one pipe fills while we're blocked reading the other.
-                        var stdoutData = Data()
-                        var stderrData = Data()
-                        let group = DispatchGroup()
-                        group.enter()
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                            group.leave()
-                        }
-                        group.enter()
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                            group.leave()
-                        }
-                        group.wait()
-
-                        process.waitUntilExit()
-
-                        continuation.resume(returning: CommandResult(
-                            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
-                            stderr: String(data: stderrData, encoding: .utf8) ?? "",
-                            exitCode: process.terminationStatus
-                        ))
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                }
+                Self.run(process, stdoutPipe: stdoutPipe, stderrPipe: stderrPipe, resuming: continuation)
             }
         } onCancel: {
             // Guard against terminating a process that hasn't started yet,
@@ -91,6 +81,73 @@ final class GitCommandExecutor: GitCommandExecuting, Sendable {
             if process.isRunning {
                 process.terminate()
             }
+        }
+    }
+
+    /// Spawns `process`, draining both pipes incrementally via `readabilityHandler`
+    /// (so output larger than the ~64KB pipe buffer can't stall the child) and
+    /// resuming `continuation` exactly once through `DispatchGroup.notify`. No
+    /// pooled thread is ever parked, so concurrent calls cannot exhaust the
+    /// libdispatch global pool.
+    private static func run(
+        _ process: Process,
+        stdoutPipe: Pipe,
+        stderrPipe: Pipe,
+        resuming continuation: CheckedContinuation<CommandResult, Error>
+    ) {
+        let stdoutBuffer = OutputBuffer()
+        let stderrBuffer = OutputBuffer()
+        let stdoutHandle = stdoutPipe.fileHandleForReading
+        let stderrHandle = stderrPipe.fileHandleForReading
+
+        // Three events must complete before resuming: stdout EOF, stderr EOF, and
+        // process termination. Each signals a single `leave()`; `notify` fires
+        // once, after all three.
+        let group = DispatchGroup()
+        group.enter()
+        group.enter()
+        group.enter()
+
+        stdoutHandle.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                group.leave()
+            } else {
+                stdoutBuffer.append(chunk)
+            }
+        }
+        stderrHandle.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                group.leave()
+            } else {
+                stderrBuffer.append(chunk)
+            }
+        }
+        process.terminationHandler = { _ in
+            group.leave()
+        }
+
+        group.notify(queue: DispatchQueue.global(qos: .userInitiated)) {
+            continuation.resume(returning: CommandResult(
+                stdout: String(data: stdoutBuffer.collected, encoding: .utf8) ?? "",
+                stderr: String(data: stderrBuffer.collected, encoding: .utf8) ?? "",
+                exitCode: process.terminationStatus
+            ))
+        }
+
+        do {
+            try process.run()
+        } catch {
+            // The process never started, so no handler fires and the group never
+            // balances (its `notify` therefore never runs, so there is no
+            // double-resume). Detach the handlers and fail the call.
+            stdoutHandle.readabilityHandler = nil
+            stderrHandle.readabilityHandler = nil
+            process.terminationHandler = nil
+            continuation.resume(throwing: error)
         }
     }
 }

--- a/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
+++ b/OhMyWorktree/ViewModels/WorktreeListViewModel.swift
@@ -79,6 +79,14 @@ final class WorktreeListViewModel {
     @ObservationIgnored private var lastLoadTime: Date?
     private static let debounceInterval: TimeInterval = 2.0
 
+    /// Upper bound on simultaneous `git log` (commit-date) lookups during
+    /// enrichment. Each `GitCommandExecutor.execute` occupies a libdispatch
+    /// worker thread while it runs, so an unbounded fan-out across a repo with
+    /// 64+ worktrees exhausts libdispatch's 64-thread global pool and deadlocks
+    /// the load forever. Keeping in-flight lookups far under that limit prevents
+    /// the pool exhaustion. See WorktreeListViewModelEnrichmentTests.
+    private static let maxConcurrentCommitDateLookups = 8
+
     var repository: Repository? {
         didSet {
             if repository?.id != oldValue?.id {
@@ -245,16 +253,23 @@ final class WorktreeListViewModel {
             result[i].prRemoteBranch = meta?.prRemoteBranch
         }
 
-        // Step 2: Fetch commit dates concurrently (issue #12)
+        // Step 2: Fetch commit dates concurrently, but BOUNDED (issue #12).
+        // A sliding window keeps at most `maxConcurrentCommitDateLookups` `git
+        // log` calls in flight at once: prime the window, then submit the next
+        // index each time one completes. This preserves parallelism while
+        // capping the fan-out far under libdispatch's 64-thread limit so the
+        // executor can never exhaust the pool (see the constant's docs).
         let manager = worktreeManager
+        let total = result.count
         await withTaskGroup(of: (Int, Date?).self) { group in
-            for i in result.indices {
+            var nextIndex = 0
+            while nextIndex < min(Self.maxConcurrentCommitDateLookups, total) {
+                let i = nextIndex
                 let path = result[i].path
-                group.addTask {
-                    let date = await manager.lastCommitDate(worktreePath: path)
-                    return (i, date)
-                }
+                group.addTask { (i, await manager.lastCommitDate(worktreePath: path)) }
+                nextIndex += 1
             }
+
             for await (index, commitDate) in group {
                 let metaActivity = metadata.first(where: { $0.folderName == result[index].folderName })?.lastActivityAt
                 switch (metaActivity, commitDate) {
@@ -262,6 +277,13 @@ final class WorktreeListViewModel {
                 case let (date1?, nil):    result[index].lastActivityAt = date1
                 case let (nil, date2?):    result[index].lastActivityAt = date2
                 case (nil, nil):           break
+                }
+
+                if nextIndex < total {
+                    let i = nextIndex
+                    let path = result[i].path
+                    group.addTask { (i, await manager.lastCommitDate(worktreePath: path)) }
+                    nextIndex += 1
                 }
             }
         }

--- a/OhMyWorktreeTests/GitCommandExecutorConcurrencyTests.swift
+++ b/OhMyWorktreeTests/GitCommandExecutorConcurrencyTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import OhMyWorktree
+
+/// Behavioral tests for the real `GitCommandExecutor` (process spawning + pipe
+/// draining). The executor is otherwise mocked everywhere; these lock in the
+/// contract the mock stands in for — most importantly that it never deadlocks
+/// the libdispatch global thread pool under high concurrency.
+@Suite("GitCommandExecutor concurrency", .serialized)
+struct GitCommandExecutorConcurrencyTests {
+
+    /// Regression for the "Loading worktrees…" freeze: the original executor
+    /// dispatched each command's blocking pipe-drain + `waitUntilExit` onto the
+    /// global pool and then blocked that worker on `DispatchGroup.wait()`. With
+    /// 64+ concurrent calls, every one of libdispatch's 64 pool threads sat in
+    /// `wait()` waiting for reader blocks that could never be scheduled (no free
+    /// thread) — a permanent deadlock. The executor must complete every call no
+    /// matter how many run at once.
+    @Test("completes all commands when concurrency exceeds the 64-thread dispatch pool",
+          .timeLimit(.minutes(1)))
+    func highConcurrency_doesNotExhaustDispatchPool() async throws {
+        let executor = GitCommandExecutor()
+        let concurrentCount = 80   // > libdispatch's 64-thread soft limit
+
+        let completed = try await withThrowingTaskGroup(of: Int32.self) { group in
+            for _ in 0..<concurrentCount {
+                group.addTask {
+                    // `/bin/sleep 0.2` keeps every invocation simultaneously in
+                    // flight so the pool is genuinely saturated; it produces no
+                    // output, isolating spawn + completion as the thing tested.
+                    let result = try await executor.execute(
+                        command: "/bin/sleep",
+                        arguments: ["0.2"],
+                        workingDirectory: nil
+                    )
+                    return result.exitCode
+                }
+            }
+            var count = 0
+            for try await code in group {
+                #expect(code == 0)
+                count += 1
+            }
+            return count
+        }
+
+        #expect(completed == concurrentCount)
+    }
+
+    @Test("captures stdout and a zero exit code")
+    func capturesStdoutAndExitCode() async throws {
+        let result = try await GitCommandExecutor().execute(
+            command: "/bin/echo", arguments: ["hello"], workingDirectory: nil
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == "hello\n")
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test("reports a non-zero exit code")
+    func reportsNonzeroExitCode() async throws {
+        let result = try await GitCommandExecutor().execute(
+            command: "/bin/sh", arguments: ["-c", "exit 3"], workingDirectory: nil
+        )
+        #expect(result.exitCode == 3)
+    }
+
+    /// Output larger than the OS pipe buffer (~64KB) must drain without
+    /// deadlocking — the child blocks on a full pipe until the reader drains it,
+    /// so reading has to happen concurrently with the process running.
+    @Test("drains output larger than the pipe buffer")
+    func drainsLargeOutput() async throws {
+        let byteCount = 200_000
+        let result = try await GitCommandExecutor().execute(
+            command: "/bin/sh",
+            arguments: ["-c", "yes x | head -c \(byteCount)"],
+            workingDirectory: nil
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.count == byteCount)
+    }
+}

--- a/OhMyWorktreeTests/WorktreeListViewModelEnrichmentTests.swift
+++ b/OhMyWorktreeTests/WorktreeListViewModelEnrichmentTests.swift
@@ -86,6 +86,21 @@ struct WorktreeListViewModelEnrichmentTests {
 
     """
 
+    /// Builds `git worktree list --porcelain` output for `count` worktrees
+    /// (index 0 is the repo root). Used to stress the enrichment fan-out.
+    private static func makePorcelain(count: Int) -> String {
+        var lines: [String] = []
+        for i in 0..<count {
+            let path = i == 0 ? "/tmp/test-repo" : "/tmp/worktrees/wt-\(i)"
+            let branch = i == 0 ? "refs/heads/main" : "refs/heads/feature/\(i)"
+            lines.append("worktree \(path)")
+            lines.append("HEAD \(String(format: "abc%04d", i))")
+            lines.append("branch \(branch)")
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
     // MARK: - Concurrent execution
 
     @Test("lastCommitDate calls run concurrently for multiple worktrees")
@@ -143,5 +158,37 @@ struct WorktreeListViewModelEnrichmentTests {
         #expect(main.lastActivityAt == Date(timeIntervalSince1970: 1_700_000_100))
         #expect(wtA.lastActivityAt == Date(timeIntervalSince1970: 1_700_000_200))
         #expect(wtB.lastActivityAt == Date(timeIntervalSince1970: 1_700_000_300))
+    }
+
+    // MARK: - Bounded concurrency
+
+    @Test("commit-date enrichment caps concurrency well below the dispatch pool limit")
+    func enrichment_capsConcurrencyBelowDispatchLimit() async {
+        // With an unbounded TaskGroup, a repo with many worktrees fans out one
+        // `git log` per worktree simultaneously. Each GitCommandExecutor.execute
+        // blocks a libdispatch worker thread on a synchronous pipe-read wait, so
+        // ~64+ concurrent calls exhaust the 64-thread global pool and deadlock
+        // "Loading worktrees…" forever. The fan-out must be bounded to a small
+        // constant, leaving ample headroom under the 64-thread limit.
+        let executor = ConcurrencyTrackingExecutor(
+            worktreeListOutput: Self.makePorcelain(count: 100),
+            logCallDelay: .milliseconds(50)
+        )
+
+        let vm = WorktreeListViewModel(
+            worktreeManager: WorktreeManager(executor: executor),
+            store: .shared,
+            pullRequestService: MockNoPRService()
+        )
+        vm.repository = testRepo
+
+        await vm.loadWorktrees()
+
+        let peak = await executor.tracker.peak
+        #expect(peak > 1, "enrichment should still run in parallel — peak was \(peak)")
+        #expect(
+            peak <= 16,
+            "enrichment must cap concurrency well under the 64-thread dispatch limit — peak was \(peak)"
+        )
     }
 }


### PR DESCRIPTION
## Problem

"Loading worktrees…" froze indefinitely for repositories with many worktrees. A `sample` of the hung app showed the main thread **idle** but **65 dispatch worker threads all blocked** at `GitCommandExecutor.execute`'s `DispatchGroup.wait()`, with `Dispatch Thread Soft Limit: 64 reached` — a libdispatch thread-pool exhaustion deadlock. No git child process was running.

## Root cause

`GitCommandExecutor.execute` dispatched each git invocation onto libdispatch's global concurrent pool, then blocked that worker on `DispatchGroup.wait()` while waiting for two *more* pooled blocks (the stdout/stderr readers). Once 64 calls ran at once, all 64 pool threads sat in `wait()` and the reader blocks they depended on could never be scheduled — a permanent deadlock.

The trigger: `WorktreeListViewModel.enriched()` fans out one `git log` per worktree with **no concurrency bound**, so a repo with ~64 worktrees fired ~64 concurrent `execute` calls and deadlocked the load every time.

## Fix (both layers)

- **Root cause —** `GitCommandExecutor` now drains both pipes incrementally via `readabilityHandler` and resumes through `DispatchGroup.notify` (never `.wait()`). No call parks a pool thread, so no concurrency level can exhaust the pool. Output larger than the ~64KB pipe buffer still drains without stalling the child.
- **Defense in depth —** `enriched()` bounds the commit-date fan-out to 8 concurrent lookups via a sliding window.

## Tests

- `GitCommandExecutorConcurrencyTests` — real-executor stress test (80 concurrent commands) that **deadlocked before (60s time-limit) and now completes in ~0.2s**, plus characterization tests for stdout capture, non-zero exit codes, and >64KB output draining.
- `WorktreeListViewModelEnrichmentTests` — new cap test: 100 worktrees, asserts peak concurrency stays bounded (was 100, now ≤ 8).

## Verification

- `swiftlint lint`: 0 violations
- Full suite: 497 tests pass
- Coverage gate (`scripts/coverage.sh`): strict 100% on 27 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)